### PR TITLE
Do not share bucket between lambda deployments.

### DIFF
--- a/aws-lambda-scorer/terraform-recipe/api_gateway.tf
+++ b/aws-lambda-scorer/terraform-recipe/api_gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_api_gateway_rest_api" "scorer_api" {
-  name = "${var.lambda_id}_api"
+  name = "${local.escaped_id}"
   description = "H2O Driverless AI Mojo Scorer API (${var.lambda_id})"
 }
 
@@ -24,7 +24,7 @@ resource "aws_api_gateway_integration" "scorer_integration" {
 
   integration_http_method = "POST"
   type = "AWS_PROXY"
-  uri = "${aws_lambda_function.scorer_lambda.invoke_arn}"
+  uri = "${aws_lambda_function.scorer.invoke_arn}"
 }
 
 resource "aws_api_gateway_deployment" "scorer_api_deployment" {
@@ -37,7 +37,7 @@ resource "aws_api_gateway_deployment" "scorer_api_deployment" {
 }
 
 resource "aws_api_gateway_usage_plan" "scorer_usage_plan" {
-  name = "${var.lambda_id}_usage_plan"
+  name = "${local.escaped_id}"
 
   api_stages {
     api_id = "${aws_api_gateway_rest_api.scorer_api.id}"
@@ -46,7 +46,7 @@ resource "aws_api_gateway_usage_plan" "scorer_usage_plan" {
 }
 
 resource "aws_api_gateway_api_key" "scorer_api_key" {
-  name = "${var.lambda_id}_api_key"
+  name = "${local.escaped_id}"
 
   stage_key {
     rest_api_id = "${aws_api_gateway_rest_api.scorer_api.id}"
@@ -63,7 +63,7 @@ resource "aws_api_gateway_usage_plan_key" "scorer_usage_plan" {
 resource "aws_lambda_permission" "apigw" {
   statement_id = "AllowExecutionFromAPIGateway"
   action = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.scorer_lambda.arn}"
+  function_name = "${aws_lambda_function.scorer.arn}"
   principal = "apigateway.amazonaws.com"
 
   # The /*/*/* part allows invocation from any stage, method and resource path

--- a/aws-lambda-scorer/terraform-recipe/main.tf
+++ b/aws-lambda-scorer/terraform-recipe/main.tf
@@ -22,6 +22,10 @@ variable "mojo_path" {
   description = "Local path to the mojo file to be pushed to S3."
 }
 
+locals {
+  escaped_id = "${replace("${var.lambda_id}", "/[^-_a-zA-Z0-9]/", "")}"
+}
+
 provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
@@ -29,28 +33,26 @@ provider "aws" {
 }
 
 // Mojo file in S3.
-resource "aws_s3_bucket" "deployment" {
-  // Note that all the deployments share the same bucket. The default limit on the number of S3 buckets is 100, so we
-  // don't want to exhaust that.
-  bucket = "h2oai-dai-lambda-models"
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${replace(local.escaped_id, "_", "-")}"
   acl = "private"
 }
 
 resource "aws_s3_bucket_object" "mojo" {
-  bucket = "${aws_s3_bucket.deployment.id}"
+  bucket = "${aws_s3_bucket.bucket.id}"
   key = "${var.lambda_id}.mojo"
   source = "${var.mojo_path}"
   etag = "${md5(file(var.mojo_path))}"
 }
 
 // AWS Lambda function with a Java implementation of the Mojo scorer.
-resource "aws_lambda_function" "scorer_lambda" {
-  function_name = "${var.lambda_id}_function"
+resource "aws_lambda_function" "scorer" {
+  function_name = "${local.escaped_id}"
   description = "H2O Driverless AI Mojo Scorer (${var.lambda_id})"
   filename = "${var.lambda_zip_path}"
   handler = "ai.h2o.mojos.deploy.aws.lambda.ApiGatewayWrapper::handleRequest"
   source_code_hash = "${base64sha256(file(var.lambda_zip_path))}"
-  role = "${aws_iam_role.scorer_lambda_iam_role.arn}"
+  role = "${aws_iam_role.scorer_iam_role.arn}"
   runtime = "java8"
 
   // Increase resource constraints from the defaults of 3s and 128MB.
@@ -59,7 +61,7 @@ resource "aws_lambda_function" "scorer_lambda" {
 
   environment {
     variables = {
-      DEPLOYMENT_S3_BUCKET_NAME = "${aws_s3_bucket.deployment.id}"
+      DEPLOYMENT_S3_BUCKET_NAME = "${aws_s3_bucket.bucket.id}"
       MOJO_S3_OBJECT_KEY = "${aws_s3_bucket_object.mojo.key}"
       DRIVERLESS_AI_LICENSE_KEY = "${var.license_key}"
       // This is not used yet by the scorer, but it is here to enforce code reload when only the mojo itself changes.
@@ -71,8 +73,8 @@ resource "aws_lambda_function" "scorer_lambda" {
 }
 
 # IAM role which dictates what other AWS services the lambda function may access.
-resource "aws_iam_role" "scorer_lambda_iam_role" {
-  name = "${var.lambda_id}_iam_role"
+resource "aws_iam_role" "scorer_iam_role" {
+  name = "${local.escaped_id}"
 
   assume_role_policy = <<EOF
 {
@@ -93,7 +95,7 @@ EOF
 
 // Allow the lambda function to read the mojo file from S3.
 resource "aws_iam_policy" "s3_policy" {
-  name = "${var.lambda_id}_s3_policy"
+  name = "${local.escaped_id}"
   description = "Allow H2O Driverless AI Mojo Scorer to access the associated model file on S3"
 
   policy = <<EOF
@@ -103,12 +105,12 @@ resource "aws_iam_policy" "s3_policy" {
     {
       "Effect": "Allow",
       "Action": ["s3:ListBucket"],
-      "Resource": ["${aws_s3_bucket.deployment.arn}"]
+      "Resource": ["${aws_s3_bucket.bucket.arn}"]
     },
     {
       "Effect": "Allow",
       "Action": ["s3:GetObject"],
-      "Resource": ["${aws_s3_bucket.deployment.arn}/${aws_s3_bucket_object.mojo.key}"]
+      "Resource": ["${aws_s3_bucket.bucket.arn}/${aws_s3_bucket_object.mojo.key}"]
     }
   ]
 }
@@ -116,6 +118,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "s3_attach" {
-  role = "${aws_iam_role.scorer_lambda_iam_role.name}"
+  role = "${aws_iam_role.scorer_iam_role.name}"
   policy_arn = "${aws_iam_policy.s3_policy.arn}"
 }


### PR DESCRIPTION
Also unifies the naming in the template and make it start with the same
prefix to be more easily navigable in combo and search widgets.