### PR TITLE
Create basic structure for local rest scorer based on SpringBoot.

### DIFF
--- a/local-rest-scorer/README.md
+++ b/local-rest-scorer/README.md
@@ -1,0 +1,87 @@
+# DAI Deployment Template for Local SpringBoot Scorer
+
+This package contains sources of a generic Java scorer implementation based on SpringBoot.
+
+
+## Building
+
+The code of the local SpringBoot scorer is a gradle project build as usual by
+`./gradlew build`.
+
+> TODO(osery): Describe how we get the executable SpringBoot jar, which needs to be embedded in the
+> distribution zip archive.
+
+> TODO(osery): Describe score configuration to pass in the model(s), the license key, and the port.
+
+
+## Running
+
+> TODO(osery): How to best run the scorer locally + what params to pass in.
+
+To test the endpoint, send a request to http://localhost:8080 as follows:
+
+```bash
+$ curl \
+    -X POST \
+    -d @test.json http://localhost:8080
+```
+
+This expects a file `test.json` with the actual scoring request payload.
+If you are using the mojo trained in `test/data/iris.csv` as suggested above,
+you should be able to use the following json payload:
+
+```json
+{
+  "fields": [
+    "sepal_len", "sepal_wid", "petal_len", "petal_wid"
+  ],
+  "includeFieldsInOutput": [
+    "sepal_len"
+  ],
+  "rows": [
+    [
+      "1.0", "1.0", "2.2", "3.5"
+    ],
+    [
+      "3.0", "10.0", "2.2", "3.5"
+    ],
+    [
+      "4.0", "100.0", "2.2", "3.5"
+    ]
+  ]
+}
+```
+
+The expected response should follow this structure, but the actual values may differ:
+
+```json
+{
+  "score": [
+    [
+      "1.0",
+      "0.6240277982943945",
+      "0.045458571508101536",
+      "0.330513630197504"
+    ],
+    [
+      "3.0",
+      "0.7209441819603676",
+      "0.06299909138586585",
+      "0.21605672665376663"
+    ],
+    [
+      "4.0",
+      "0.7209441819603676",
+      "0.06299909138586585",
+      "0.21605672665376663"
+    ]
+  ]
+}
+```
+
+Alternatively, you can use SpringFox endpoints that allow both programmatic and manual inspection
+of the API:
+
+* Swagger JSON representation for programmatic access: http://localhost:8080/v2/api-docs.
+* The UI for manual API inspection: http://localhost:8080/swagger-ui.html.
+

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -1,0 +1,49 @@
+plugins {
+    id "java"
+    id 'org.hidetake.swagger.generator' version '2.15.0'
+
+    id 'org.springframework.boot' version '2.1.1.RELEASE'
+}
+
+apply plugin: 'io.spring.dependency-management'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+
+    def localNexusLocation = "http://nexus:8081/nexus/repository"
+    maven {
+        url "$localNexusLocation/releases/"
+    }
+}
+
+dependencies {
+    compile group: 'ai.h2o', name: 'mojo2-runtime-api', version: '0.13.7'
+    compile group: 'ai.h2o', name: 'mojo2-runtime-impl', version: '0.13.7'
+    compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+    compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+    compile group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.0.5'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.0'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+swaggerSources {
+    scorer {
+        inputFile = file('../common/rest-api/swagger.yaml')
+        code {
+            language = 'spring'
+            configFile = file('swagger_codegen.json')
+            components = [models: true, apis: true]
+            dependsOn validation
+        }
+    }
+}
+compileJava.dependsOn swaggerSources.scorer.code
+sourceSets.main.java.srcDir "${swaggerSources.scorer.code.outputDir}/src/main/java"
+
+// TODO(osery): Include the executable StringBoot jar in the distribution zip file here.

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/ScorerApplication.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/ScorerApplication.java
@@ -1,0 +1,13 @@
+package ai.h2o.mojos.deploy.local.rest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@SpringBootApplication
+@EnableSwagger2
+public class ScorerApplication {
+    public static void main(String[] args) {
+        new SpringApplication(ScorerApplication.class).run(args);
+    }
+}

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -1,0 +1,44 @@
+package ai.h2o.mojos.deploy.local.rest.controller;
+
+import ai.h2o.mojos.deploy.local.rest.api.ModelsApi;
+import ai.h2o.mojos.deploy.local.rest.model.Model;
+import ai.h2o.mojos.deploy.local.rest.model.ScoreRequest;
+import ai.h2o.mojos.deploy.local.rest.model.ScoreResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Controller
+public class ModelsApiController implements ModelsApi {
+
+    private static final Logger log = LoggerFactory.getLogger(ModelsApiController.class);
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public ModelsApiController() {
+    }
+
+    public ResponseEntity<Model> getModelInfo(String id) {
+        log.error("Ignoring request getModelInfo for model id: {}", id);
+        return new ResponseEntity<Model>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    public ResponseEntity<List<String>> getModels() {
+        log.error("Ignoring request getModels");
+        return new ResponseEntity<List<String>>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    public ResponseEntity<ScoreResponse> getScore(ScoreRequest body, String id) {
+        log.error("Ignoring request getScore for model id: {}, request: {}", id, body);
+        return new ResponseEntity<ScoreResponse>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    public ResponseEntity<ScoreResponse> getScoreByFile(String id, String file) {
+        log.error("Ignoring request getScoreByFile for model id: {}, file: {}", id, file);
+        return new ResponseEntity<ScoreResponse>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+}

--- a/local-rest-scorer/swagger_codegen.json
+++ b/local-rest-scorer/swagger_codegen.json
@@ -1,0 +1,7 @@
+{
+  "basePackage":"ai.h2o.mojos.deploy.local.rest",
+  "configPackage":"ai.h2o.mojos.deploy.local.rest.config",
+  "modelPackage": "ai.h2o.mojos.deploy.local.rest.model",
+  "apiPackage" : "ai.h2o.mojos.deploy.local.rest.api",
+  "interfaceOnly" : true
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'dai-deployment-templates'
 include 'aws-lambda-scorer:lambda-template'
 include 'aws-lambda-scorer:terraform-recipe'
+include 'local-rest-scorer'


### PR DESCRIPTION
This is an adaptation of h2oai/h2oai#4725, however there are important
differences for code maintenability:
* Generate code from during build to prevent divergence and ensure
  repeatability.
* Never submit autogenerated code... ever.
* Switch to gradle to fit the dai-deployment-templates build system.

This is just the skeleton part, I will move the actual evaluation code
in the next steps.

Wip on #22.