### PR TITLE
Improve errors handling for malformed requests.

### DIFF
--- a/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/ApiGatewayWrapper.java
+++ b/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/ApiGatewayWrapper.java
@@ -2,16 +2,20 @@ package ai.h2o.mojos.deploy.aws.lambda;
 
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
+import ai.h2o.mojos.deploy.common.transform.ScoreRequestFormatException;
 import ai.h2o.mojos.runtime.lic.LicenseException;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.apache.http.HttpStatus;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 /**
  * Wraps {@link MojoScorer} so that it can be called via the AWS API gateway.
@@ -23,7 +27,7 @@ import java.io.IOException;
  * Build an API Gateway API with Lambda Proxy Integration</a>
  */
 public class ApiGatewayWrapper implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    private final Gson gson = new Gson();
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private final MojoScorer mojoScorer = new MojoScorer();
 
     @Override
@@ -33,18 +37,36 @@ public class ApiGatewayWrapper implements RequestHandler<APIGatewayProxyRequestE
             ScoreResponse scoreResponse = mojoScorer.score(scoreRequest, context);
             return toSuccessResponse(gson.toJson(scoreResponse));
         } catch (JsonSyntaxException e) {
-            return toErrorResponse(HttpStatus.SC_BAD_REQUEST, e);
+            return toErrorResponse(HttpStatus.SC_BAD_REQUEST, "Malformed JSON request", e);
+        } catch (ScoreRequestFormatException e) {
+            return toRequestFormatResponse(e);
         } catch (IOException e) {
-            return toErrorResponse(HttpStatus.SC_NOT_FOUND, e);
+            return toErrorResponse(HttpStatus.SC_NOT_FOUND, "Mojo pipeline file not found", e);
         } catch (LicenseException e) {
-            return toErrorResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, e);
+            return toErrorResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "Could not find a valid license file", e);
         } catch (Exception e) {
-            return toErrorResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR, e);
+            return toErrorResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR, "Unexpected error while scoring", e);
         }
     }
 
-    private static APIGatewayProxyResponseEvent toErrorResponse(int statusCode, Exception exception) {
-        return new APIGatewayProxyResponseEvent().withStatusCode(statusCode).withBody(exception.toString());
+    private static APIGatewayProxyResponseEvent toErrorResponse(int statusCode, String message, Exception exception) {
+        String exceptionAsString = getExceptionAsString(exception);
+        return new APIGatewayProxyResponseEvent().withStatusCode(statusCode).withBody(
+                String.format("%s\n\nError details:\n%s\n", message, exceptionAsString));
+    }
+
+    private static String getExceptionAsString(Exception exception) {
+        StringWriter sw = new StringWriter();
+        exception.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+
+    private APIGatewayProxyResponseEvent toRequestFormatResponse(ScoreRequestFormatException exception) {
+        String exceptionAsString = getExceptionAsString(exception);
+        String example = gson.toJson(exception.getExampleRequest());
+        return new APIGatewayProxyResponseEvent().withStatusCode(HttpStatus.SC_BAD_REQUEST).withBody(
+                String.format("Malformed scoring request.\n\nError details:\n%s\n\nExample request:\n%s\n",
+                        exceptionAsString, example));
     }
 
     private static APIGatewayProxyResponseEvent toSuccessResponse(String body) {

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
@@ -1,0 +1,88 @@
+package ai.h2o.mojos.deploy.common.transform;
+
+import ai.h2o.mojos.deploy.common.rest.model.Row;
+import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
+import ai.h2o.mojos.runtime.frame.MojoColumn;
+import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Checks that the request is of the correct form matching the corresponding mojo pipeline.
+ */
+public class RequestChecker {
+
+    /**
+     * Verify that the request is valid and matches the expected {@link MojoFrameMeta}.
+     *
+     * @throws ScoreRequestFormatException on any issues.
+     */
+    public void verify(ScoreRequest scoreRequest, MojoFrameMeta expectedMeta) throws ScoreRequestFormatException {
+        String message = getProblemMessageOrNull(scoreRequest, expectedMeta);
+        if (message == null) {
+            return;
+        }
+        throw new ScoreRequestFormatException(message, getExampleRequest(expectedMeta));
+    }
+
+    private String getProblemMessageOrNull(ScoreRequest scoreRequest, MojoFrameMeta expectedMeta) {
+        if (scoreRequest == null) {
+            return "Request cannot be empty";
+        }
+        List<String> fields = scoreRequest.getFields();
+        if (fields == null || fields.isEmpty()) {
+            return "List of input fields cannot be empty";
+        }
+        List<Row> rows = scoreRequest.getRows();
+        if (rows == null || rows.isEmpty()) {
+            return "List of input data rows cannot be empty";
+        }
+        Set expFields = new HashSet<String>(asList(expectedMeta.getColumnNames()));
+        if (!expFields.equals(new HashSet<String>(fields))) {
+            return String.format("Input fields don't match the Mojo, expected %s actual %s",
+                    Arrays.toString(expectedMeta.getColumnNames()), fields.toString());
+        }
+        int i = 0;
+        for (Row row : scoreRequest.getRows()) {
+            if (row.size() != fields.size()) {
+                return String.format("Not enough elements in row %d (zero-indexed)", i);
+            }
+            i++;
+        }
+        return null;
+    }
+
+    private static ScoreRequest getExampleRequest(MojoFrameMeta expectedMeta) {
+        ScoreRequest request = new ScoreRequest();
+        request.setFields(asList(expectedMeta.getColumnNames()));
+        Row row = new Row();
+        for (MojoColumn.Type type : expectedMeta.getColumnTypes()) {
+            row.add(getExampleValue(type));
+        }
+        request.addRowsItem(row);
+        return request;
+    }
+
+    private static String getExampleValue(MojoColumn.Type type) {
+        switch (type) {
+            case Bool:
+                return "true";
+            case Int32:
+            case Int64:
+            case Float32:
+            case Float64:
+                return "0";
+            case Str:
+                return "text";
+            case Time64:
+                return "2018-01-01";
+            default:
+                return "";
+        }
+    }
+}

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/ScoreRequestFormatException.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/ScoreRequestFormatException.java
@@ -1,0 +1,19 @@
+package ai.h2o.mojos.deploy.common.transform;
+
+import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
+
+/**
+ * Thrown on issues with the {@link ScoreRequest}.
+ */
+public class ScoreRequestFormatException extends Exception {
+    private final ScoreRequest exampleRequest;
+
+    public ScoreRequestFormatException(String message, ScoreRequest exampleRequest) {
+        super(message);
+        this.exampleRequest = exampleRequest;
+    }
+
+    public ScoreRequest getExampleRequest() {
+        return exampleRequest;
+    }
+}

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
@@ -1,0 +1,125 @@
+package ai.h2o.mojos.deploy.common.transform;
+
+import ai.h2o.mojos.deploy.common.rest.model.Row;
+import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
+import ai.h2o.mojos.runtime.frame.MojoColumn;
+import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RequestCheckerTest {
+    private final RequestChecker checker = new RequestChecker();
+
+    @Test
+    void verifyValidRequest_succeeds() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        request.addFieldsItem("field1");
+        request.addRowsItem(toRow("text"));
+        MojoFrameMeta expectedMeta = new MojoFrameMeta(
+                new String[]{"field1"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str});
+
+        // When
+        checker.verify(request, expectedMeta);
+
+        // Then all ok
+    }
+
+    @Test
+    void verifyNullRequest_throws() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = null;
+        MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
+
+        // When & then
+        ScoreRequestFormatException exception =
+                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+        assertThat(exception.getMessage()).contains("empty");
+    }
+
+    @Test
+    void verifyEmptyRequest_throws() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
+
+        // When & then
+        ScoreRequestFormatException exception =
+                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+        assertThat(exception.getMessage()).contains("empty");
+    }
+
+    @Test
+    void verifyEmptyFieldsRequest_throws() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        request.addRowsItem(toRow("text"));
+        MojoFrameMeta expectedMeta = new MojoFrameMeta(
+                new String[]{"field1"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str});
+
+        // When & then
+        ScoreRequestFormatException exception =
+                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+        assertThat(exception.getMessage()).contains("fields cannot be empty");
+    }
+
+    @Test
+    void verifyEmptyRowsRequest_throws() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        request.addFieldsItem("field1");
+        MojoFrameMeta expectedMeta = new MojoFrameMeta(
+                new String[]{"field1"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str});
+
+        // When & then
+        ScoreRequestFormatException exception =
+                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+        assertThat(exception.getMessage()).contains("rows cannot be empty");
+    }
+
+    @Test
+    void verifyMismatchedFieldsRequest_throws() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        request.addFieldsItem("a_fields");
+        request.addRowsItem(toRow("text"));
+        MojoFrameMeta expectedMeta = new MojoFrameMeta(
+                new String[]{"different_fields"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str});
+
+        // When & then
+        ScoreRequestFormatException exception =
+                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+        assertThat(exception.getMessage()).contains("fields don't match");
+    }
+
+    @Test
+    void verifyMismatchedRowsRequest_throws() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        request.addFieldsItem("field1");
+        request.addRowsItem(toRow("text"));
+        request.addRowsItem(toRow("text", "additional text"));
+        MojoFrameMeta expectedMeta = new MojoFrameMeta(
+                new String[]{"field1"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str});
+
+        // When & then
+        ScoreRequestFormatException exception =
+                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+        assertThat(exception.getMessage()).contains("row 1");
+    }
+
+    private static Row toRow(String... values) {
+        Row row = new Row();
+        row.addAll(Arrays.asList(values));
+        return row;
+    }
+}


### PR DESCRIPTION
Add stack trace for more useful error reports.
Add example requests for malformed scoring requests.

Will solve h2oai/h2oai/issues/6441 and #31 once released and version bump in DAI.