### PR TITLE
Fix parsing of missing values in AWS lambda and Spring Boot deployments.

### DIFF
--- a/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
+++ b/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
@@ -46,7 +46,7 @@ public final class MojoScorer {
         MojoPipeline mojoPipeline = getMojoPipeline(logger);
         requestChecker.verify(request, mojoPipeline.getInputMeta());
         logger.log("Scoring request verified");
-        MojoFrame requestFrame = requestConverter.apply(request, mojoPipeline.getInputMeta());
+        MojoFrame requestFrame = requestConverter.apply(request, mojoPipeline.getInputFrameBuilder());
         logger.log(String.format("Input has %d rows, %d columns: %s", requestFrame.getNrows(), requestFrame.getNcols(),
                 Arrays.toString(requestFrame.getColumnNames())));
         MojoFrame responseFrame = mojoPipeline.transform(requestFrame);

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/CsvToMojoFrameConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/CsvToMojoFrameConverter.java
@@ -2,7 +2,6 @@ package ai.h2o.mojos.deploy.common.transform;
 
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
-import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
 import ai.h2o.mojos.runtime.utils.SimpleCSV;
 
@@ -13,17 +12,16 @@ import java.io.InputStream;
  * Converts the CSV from {@link InputStream} to the {@link MojoFrame} for scoring.
  */
 public class CsvToMojoFrameConverter {
-    public MojoFrame apply(InputStream inputStream, MojoFrameMeta meta) throws IOException {
+    public MojoFrame apply(InputStream inputStream, MojoFrameBuilder frameBuilder) throws IOException {
+        MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
         SimpleCSV csv = SimpleCSV.read(inputStream);
         String[] labels = csv.getLabels();
-        if (labels.length != meta.size()) {
+        if (labels.length != rowBuilder.size()) {
             throw new IllegalArgumentException(
                     String.format("Mismatch between column counts of CSV file and the mojo (csv=%d, mojo=%d).",
-                            labels.length, meta.size()));
+                            labels.length, rowBuilder.size()));
         }
 
-        MojoFrameBuilder frameBuilder = new MojoFrameBuilder(meta);
-        MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
         String[][] data = csv.getData();
         for (String[] row : data) {
             for (int c = 0; c < row.length; c++) {

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestToMojoFrameConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestToMojoFrameConverter.java
@@ -4,7 +4,6 @@ import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
-import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
 
 import java.util.List;
@@ -13,10 +12,9 @@ import java.util.function.BiFunction;
 /**
  * Converts the original API request object {@link ScoreRequest} into the input {@link MojoFrame}.
  */
-public class RequestToMojoFrameConverter implements BiFunction<ScoreRequest, MojoFrameMeta, MojoFrame> {
+public class RequestToMojoFrameConverter implements BiFunction<ScoreRequest, MojoFrameBuilder, MojoFrame> {
     @Override
-    public MojoFrame apply(ScoreRequest scoreRequest, MojoFrameMeta meta) {
-        MojoFrameBuilder frameBuilder = new MojoFrameBuilder(meta);
+    public MojoFrame apply(ScoreRequest scoreRequest, MojoFrameBuilder frameBuilder) {
         List<String> fields = scoreRequest.getFields();
 
         if (scoreRequest.getRows() != null) {

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
@@ -31,7 +31,7 @@ class RequestCheckerTest {
     }
 
     @Test
-    void verifyNullRequest_throws() throws ScoreRequestFormatException {
+    void verifyNullRequest_throws() {
         // Given
         ScoreRequest request = null;
         MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
@@ -43,7 +43,7 @@ class RequestCheckerTest {
     }
 
     @Test
-    void verifyEmptyRequest_throws() throws ScoreRequestFormatException {
+    void verifyEmptyRequest_throws() {
         // Given
         ScoreRequest request = new ScoreRequest();
         MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
@@ -55,7 +55,7 @@ class RequestCheckerTest {
     }
 
     @Test
-    void verifyEmptyFieldsRequest_throws() throws ScoreRequestFormatException {
+    void verifyEmptyFieldsRequest_throws() {
         // Given
         ScoreRequest request = new ScoreRequest();
         request.addRowsItem(toRow("text"));
@@ -70,7 +70,7 @@ class RequestCheckerTest {
     }
 
     @Test
-    void verifyEmptyRowsRequest_throws() throws ScoreRequestFormatException {
+    void verifyEmptyRowsRequest_throws() {
         // Given
         ScoreRequest request = new ScoreRequest();
         request.addFieldsItem("field1");
@@ -85,7 +85,7 @@ class RequestCheckerTest {
     }
 
     @Test
-    void verifyMismatchedFieldsRequest_throws() throws ScoreRequestFormatException {
+    void verifyMismatchedFieldsRequest_throws() {
         // Given
         ScoreRequest request = new ScoreRequest();
         request.addFieldsItem("a_fields");
@@ -101,7 +101,7 @@ class RequestCheckerTest {
     }
 
     @Test
-    void verifyMismatchedRowsRequest_throws() throws ScoreRequestFormatException {
+    void verifyMismatchedRowsRequest_throws() {
         // Given
         ScoreRequest request = new ScoreRequest();
         request.addFieldsItem("field1");

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/MojoScorer.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/MojoScorer.java
@@ -50,7 +50,7 @@ class MojoScorer {
 
     ScoreResponse score(ScoreRequest request) {
         log.info("Got scoring request: {}", request);
-        MojoFrame requestFrame = requestConverter.apply(request, pipeline.getInputMeta());
+        MojoFrame requestFrame = requestConverter.apply(request, pipeline.getInputFrameBuilder());
         MojoFrame responseFrame = doScore(requestFrame);
         ScoreResponse response = responseConverter.apply(responseFrame, request);
         response.id(pipeline.getUuid());
@@ -61,7 +61,7 @@ class MojoScorer {
         log.info("Got scoring request for CSV: {}", csvFilePath);
         MojoFrame requestFrame;
         try (InputStream csvStream = getInputStream(csvFilePath)) {
-            requestFrame = csvConverter.apply(csvStream, pipeline.getInputMeta());
+            requestFrame = csvConverter.apply(csvStream, pipeline.getInputFrameBuilder());
         }
         MojoFrame responseFrame = doScore(requestFrame);
         ScoreResponse response = responseConverter.apply(responseFrame, new ScoreRequest());


### PR DESCRIPTION
A mojo pipeline contains the list of missing values literals, which
was not passed to the REST request transformation and thus values such
as `NA` would not get interpretted as missing.

This PR fixes the issue for both AWS lambda and Spring Boot deployment
templates.

Bug: h2oai/h2oai/issues/7346