### PR TITLE
Fixes missing value support in the KDB deployment template.

### DIFF
--- a/kdb-mojo-scorer/src/main/java/ai/h2o/mojos/deploy/kdb/KdbExample.java
+++ b/kdb-mojo-scorer/src/main/java/ai/h2o/mojos/deploy/kdb/KdbExample.java
@@ -1,15 +1,12 @@
 package ai.h2o.mojos.deploy.kdb;
 
+import ai.h2o.mojos.deploy.common.kdb.KdbClientFactory;
 import ai.h2o.mojos.runtime.MojoPipeline;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
-import ai.h2o.mojos.deploy.kdb.KdbMojoInterface;
-import ai.h2o.mojos.deploy.common.kdb.KdbClientFactory;
-import ai.h2o.mojos.deploy.common.kdb.KdbCredentials;
-import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 import kx.c;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
 import org.apache.commons.cli.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
@@ -50,7 +47,6 @@ public class KdbExample {
             log.info("Beginning to load mojo pipeline");
             MojoPipeline model = MojoPipeline.loadFrom(mojoFilePath);
             log.info("Successfully Loaded Mojo Pipeline.");
-            MojoFrameMeta mojoMeta = model.getInputMeta();
             if (!kdbAuthFilePath.equals("")) {
                 kdbClient = KdbClientFactory.createKdbClient(kdbHost, kdbPort, kdbAuthFilePath);
             } else {
@@ -62,7 +58,7 @@ public class KdbExample {
                 if ((counter % 10) == 0) {
                     log.info("Processed {} responses from KDB", counter);
                 }
-                MojoFrame iframe = KdbMojoInterface.Parse(kdbResponse, mojoMeta, dropColumns);
+                MojoFrame iframe = KdbMojoInterface.Parse(kdbResponse, model.getInputFrameBuilder(), dropColumns);
                 MojoFrame oframe = model.transform(iframe);
                 KdbMojoInterface.Publish(kdbSubscribedClient, kdbResponse, qPubTable, oframe);
                 counter++;

--- a/kdb-mojo-scorer/src/main/java/ai/h2o/mojos/deploy/kdb/KdbMojoInterface.java
+++ b/kdb-mojo-scorer/src/main/java/ai/h2o/mojos/deploy/kdb/KdbMojoInterface.java
@@ -1,15 +1,13 @@
 package ai.h2o.mojos.deploy.kdb;
 
-import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+import ai.h2o.mojos.runtime.frame.MojoFrame;
+import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import kx.c;
 import kx.c.Flip;
-import ai.h2o.mojos.deploy.kdb.MojoKdbTransform;
-import java.io.IOException;
-import ai.h2o.mojos.runtime.MojoPipeline;
-import ai.h2o.mojos.runtime.frame.MojoFrame;
-import ai.h2o.mojos.runtime.lic.LicenseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 
 public class KdbMojoInterface {
@@ -47,13 +45,13 @@ public class KdbMojoInterface {
      * Method to parse data obtained from KDB Tickerplant and convert to MojoFrame for inference
      *
      * @param kdbResponse Object[], response from KDB Tickerplant (new data) typically obtained from: Object kdbResponse = subscribedKdbClient.k();
-     * @param mojoMeta MojoFrameMeta, Metadata associated with the mojo artifact, defining the shape/columns/type of data in the MojoFrame
+     * @param frameBuilder Frame builder with metadata defining the shape/columns/type of data in the MojoFrame
      * @param dropCols String, comma separated list of columns that user wishes to drop prior to creating the MojoFrame. Ex. time,sym,optionalOtherDroppedColumn
      * @return MojoFrame, contains new data from KDB converted into MojoFrame for inference
      */
-    public static MojoFrame Parse(Object[] kdbResponse, MojoFrameMeta mojoMeta, String dropCols) throws IOException {
+    public static MojoFrame Parse(Object[] kdbResponse, MojoFrameBuilder frameBuilder, String dropCols) throws IOException {
         Flip kdbFlipTable = (c.Flip) kdbResponse[2];
-        return MojoKdbTransform.createMojoFrameFromKdbFlip(mojoMeta, kdbFlipTable, dropCols);
+        return MojoKdbTransform.createMojoFrameFromKdbFlip(frameBuilder, kdbFlipTable, dropCols);
     }
 
     /**

--- a/kdb-mojo-scorer/src/main/java/ai/h2o/mojos/deploy/kdb/MojoKdbTransform.java
+++ b/kdb-mojo-scorer/src/main/java/ai/h2o/mojos/deploy/kdb/MojoKdbTransform.java
@@ -1,30 +1,29 @@
 package ai.h2o.mojos.deploy.kdb;
 
-import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
-import kx.c;
-import kx.c.Flip;
-import static kx.c.n;
-import ai.h2o.mojos.runtime.MojoPipeline;
+import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
-import ai.h2o.mojos.runtime.frame.MojoFrame;
-import java.io.UnsupportedEncodingException;
-import org.slf4j.LoggerFactory;
+import kx.c;
+import kx.c.Flip;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.List;
+
+import static kx.c.n;
 
 
 class MojoKdbTransform {
 
     private static final Logger log = LoggerFactory.getLogger(MojoKdbTransform.class);
 
-    static MojoFrame createMojoFrameFromKdbFlip(MojoFrameMeta mojoMeta, Flip kdbFlipTable, String dropCols) throws UnsupportedEncodingException {
+    static MojoFrame createMojoFrameFromKdbFlip(MojoFrameBuilder frameBuilder, Flip kdbFlipTable, String dropCols) throws UnsupportedEncodingException {
         String[] colNames = kdbFlipTable.x;
         Object[] colData = kdbFlipTable.y;
         String[] colsToDrop = dropCols.split(",");
         List<String> dropColsList = Arrays.asList(colsToDrop);
-        MojoFrameBuilder frameBuilder = new MojoFrameBuilder(mojoMeta);
         for (int row = 0; row < n(colData[0]); row++) {
             MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
             for (int col = 0; col < colNames.length; col++) {

--- a/kdb-mojo-scorer/src/test/java/ai/h2o/mojos/deploy/kdb/MojoKdbTransformTest.java
+++ b/kdb-mojo-scorer/src/test/java/ai/h2o/mojos/deploy/kdb/MojoKdbTransformTest.java
@@ -1,18 +1,17 @@
 package ai.h2o.mojos.deploy.kdb;
 
-import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
-import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.jupiter.api.Test;
-import static com.google.common.truth.Truth.assertThat;
-import ai.h2o.mojos.runtime.MojoPipeline;
-import ai.h2o.mojos.runtime.frame.MojoFrame;
-import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 import ai.h2o.mojos.runtime.frame.MojoColumn.Type;
-import ai.h2o.mojos.runtime.lic.LicenseException;
+import ai.h2o.mojos.runtime.frame.MojoFrame;
+import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
+import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
 import kx.c;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Collections.singletonList;
 
 
 class MojoKdbTransformTest {
@@ -21,11 +20,11 @@ class MojoKdbTransformTest {
     void validateMojoTransform() throws IOException {
         // Given
         String dropCols = "";
-        MojoFrameMeta mojoMetaInput = generateMojoFrameMetaInput();
+        MojoFrameBuilder frameBuilder = generateMojoFrameBuilder();
         c.Flip kdbFlipTable = generateDummyFlip();
 
         // When
-        MojoFrame iframe = MojoKdbTransform.createMojoFrameFromKdbFlip(mojoMetaInput, kdbFlipTable, dropCols);
+        MojoFrame iframe = MojoKdbTransform.createMojoFrameFromKdbFlip(frameBuilder, kdbFlipTable, dropCols);
         iframe.debug();
 
         // Then
@@ -52,7 +51,7 @@ class MojoKdbTransformTest {
     }
 
     private c.Flip generateDummyFlip() {
-        int[] limBal = {20000, 120000};
+        String[] limBal = {"20000", "NA"};
         int[] sex = {1, 2};
         int[] education = {5, 1};
         int[] marriage = {3,0};
@@ -84,14 +83,14 @@ class MojoKdbTransformTest {
         return new c.Flip(dict);
     }
 
-    private MojoFrameMeta generateMojoFrameMetaInput() {
+    private MojoFrameBuilder generateMojoFrameBuilder() {
         Type[] types = {Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64,
                 Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64,
                 Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64, Type.Int64};
         String[] names = {"LIMIT_BAL", "SEX", "EDUCATION", "MARRIAGE", "AGE", "PAY_1",
                 "PAY_2", "PAY_3", "PAY_4", "PAY_5", "PAY_6", "BILL_AMT1", "BILL_AMT2", "BILL_AMT3", "BILL_AMT4",
                 "BILL_AMT5", "BILL_AMT6", "PAY_AMT1", "PAY_AMT2", "PAY_AMT3", "PAY_AMT4", "PAY_AMT5", "PAY_AMT6"};
-        return new MojoFrameMeta(names, types);
+        return new MojoFrameBuilder(new MojoFrameMeta(names, types), singletonList("NA"));
     }
 
     private MojoFrame generateDummyTransformedMojoFrame() {


### PR DESCRIPTION
A mojo pipeline contains the list of missing values literals, which
was not passed to the MojoKdbTransform and thus values such as `NA`
would not get interpreted as missing.

This PR fixes the issue for the KDB deployment template.

Context: h2oai/h2oai/issues/7346