### PR TITLE
Only do releases from a branch staring with 'release'.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,8 +105,9 @@ pipeline {
 }
 
 /**
- * @return Version specified in gradle.properties. Fails if master contains a release version (to prevent pushing
- * release version accidentally).
+ * Returns version specified in gradle.properties.
+ *
+ * Fails if master contains a release version (to prevent pushing release version accidentally).
  */
 def getVersion() {
     def version = sh(
@@ -122,21 +123,21 @@ def getVersion() {
 }
 
 /**
- * @return True, if the given version string denotes a release (not a snapshot) version.
+ * Returns true, if the given version string denotes a release (not a snapshot) version.
  */
 def isReleaseVersion(version) {
     return !version.endsWith("-SNAPSHOT")
 }
 
 /**
- * @return True, if we are on the master branch.
+ * Returns true, if we are on the master branch.
  */
 def isMasterBranch() {
     return env.BRANCH_NAME == "master"
 }
 
 /**
- * @return True, if we are on a release branch.
+ * Returns true, if we are on a release branch.
  */
 def isReleaseBranch() {
     return env.BRANCH_NAME.startsWith("release")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
             steps {
                 script {
                     sh "JAVA_HOME=${DOCKER_JAVA_HOME} ./gradlew distributionZip"
-                    if (isRelease(VERSION)) {
+                    if (isReleaseVersion(VERSION)) {
                         utilsLib.appendBuildDescription("Release ${VERSION}")
                     }
                 }
@@ -95,7 +95,7 @@ pipeline {
                         artifactId = 'dai-deployment-templates'
                         version = VERSION
                         keepPrivate = false
-                        isRelease = isReleaseVersion(version)
+                        isRelease = isReleaseVersion(VERSION)
                         platform = "any"
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
             agent { label NODE_LABEL }
             when {
                 expression {
-                    return isRelease() || isMaster()
+                    return isReleaseBranch() || isMasterBranch()
                 }
             }
             steps {
@@ -115,22 +115,29 @@ def getVersion() {
     if (!version) {
         error "Version must be set"
     }
-    if (isMaster() && !version.endsWith("-SNAPSHOT")) {
+    if (isMasterBranch() && !isSnapshotVersion(version)) {
         error "Master contains a non-snapshot version"
     }
     return version
 }
 
 /**
+ * @return True, if the given version string denotes a snapshot version.
+ */
+def isSnapshotVersion(version) {
+    return version.endsWith("-SNAPSHOT")
+}
+
+/**
  * @return True, if we are on the master branch.
  */
-def isMaster() {
+def isMasterBranch() {
     return env.BRANCH_NAME == "master"
 }
 
 /**
- * @return True, if we are on the release branch.
+ * @return True, if we are on a release branch.
  */
-def isRelease() {
+def isReleaseBranch() {
     return env.BRANCH_NAME.startsWith("release")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
                         artifactId = 'dai-deployment-templates'
                         version = VERSION
                         keepPrivate = false
-                        isRelease = isRelease()
+                        isRelease = isReleaseVersion(version)
                         platform = "any"
                     }
                 }
@@ -115,17 +115,17 @@ def getVersion() {
     if (!version) {
         error "Version must be set"
     }
-    if (isMasterBranch() && !isSnapshotVersion(version)) {
+    if (isMasterBranch() && isReleaseVersion(version)) {
         error "Master contains a non-snapshot version"
     }
     return version
 }
 
 /**
- * @return True, if the given version string denotes a snapshot version.
+ * @return True, if the given version string denotes a release (not a snapshot) version.
  */
-def isSnapshotVersion(version) {
-    return version.endsWith("-SNAPSHOT")
+def isReleaseVersion(version) {
+    return !version.endsWith("-SNAPSHOT")
 }
 
 /**


### PR DESCRIPTION
The plan is to have `master` (as opposed to `dev`) as the main branch but only allow SNAPSHOTS built there. The actual releases would get built in branch `release` and later on possibly in dedicated versioned release branches such as `release-1.0.0`.