### PR TITLE
Create aws s3 bucket outside of template

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.0.7-SNAPSHOT
+version = 0.1.1
 
 # Versions of dependencies. Try to keep these at the same version across the deployment templates to facilitate
 # issue resolution.


### PR DESCRIPTION
This change is required, because terraform cannot adopt existing buckets outside of us-east-1.
h2oai/h2oai#8249