### PR TITLE
Remove H2O.ai nexus as we now push mojo runtime to the public one.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,6 @@ buildscript {
 subprojects {
     repositories {
         mavenCentral()
-
-        // Local H2O Nexus for fetching internal dependencies, e.g., mojo runtime.
-        def localNexusLocation = "http://nexus:8081/nexus/repository"
-        maven {
-            url "$localNexusLocation/releases/"
-        }
     }
 
     apply plugin: 'io.spring.dependency-management'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 0.2.2-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
-mojoRuntimeVersion = 0.13.21
+mojoRuntimeVersion = 0.13.25
 
 # External dependencies:
 awsLambdaCoreVersion = 1.2.0


### PR DESCRIPTION
The first publically pushed version is 0.13.25.