### PR TITLE
Allow extra fields in scoring requests.

### DIFF
--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
@@ -42,10 +42,10 @@ public class RequestChecker {
         if (rows == null || rows.isEmpty()) {
             return "List of input data rows cannot be empty";
         }
-        Set expFields = new HashSet<String>(asList(expectedMeta.getColumnNames()));
-        if (!expFields.equals(new HashSet<String>(fields))) {
-            return String.format("Input fields don't match the Mojo, expected %s actual %s",
-                    Arrays.toString(expectedMeta.getColumnNames()), fields.toString());
+        List<String> expectedFields = asList(expectedMeta.getColumnNames());
+        if (!fields.containsAll(expectedFields)) {
+            return String.format("Input fields don't contain all the Mojo fields, expected %s actual %s",
+                    expectedFields.toString(), fields.toString());
         }
         int i = 0;
         for (Row row : scoreRequest.getRows()) {

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
@@ -5,10 +5,7 @@ import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoColumn;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static java.util.Arrays.asList;
 

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
@@ -97,7 +97,40 @@ class RequestCheckerTest {
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("fields don't match");
+        assertThat(exception.getMessage()).contains("fields don't contain all");
+    }
+
+    @Test
+    void verifyTooFewFieldsRequest_throws() {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        request.addFieldsItem("field1");
+        request.addRowsItem(toRow("text"));
+        MojoFrameMeta expectedMeta = new MojoFrameMeta(
+                new String[]{"field1", "field2"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str, MojoColumn.Type.Str});
+
+        // When & then
+        ScoreRequestFormatException exception =
+                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+        assertThat(exception.getMessage()).contains("fields don't contain all");
+    }
+
+    @Test
+    void verifyExtraFieldsRequest_succeeds() throws ScoreRequestFormatException {
+        // Given
+        ScoreRequest request = new ScoreRequest();
+        request.addFieldsItem("field1");
+        request.addFieldsItem("field2");
+        request.addRowsItem(toRow("text1", "text2"));
+        MojoFrameMeta expectedMeta = new MojoFrameMeta(
+                new String[]{"field1"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str});
+
+        // When
+        checker.verify(request, expectedMeta);
+
+        // Then all ok
     }
 
     @Test


### PR DESCRIPTION
This has been requested in: https://github.com/h2oai/h2oai/issues/9395.
I don't think that we want to allow subset of fields in the requests as it may silently ignore typos in the input data (we already saw an example of that with the local scorer). So keeping that side of the check intact.

Also duplicated here: #70.