### PR TITLE
[MOJO] update the runtime version to 2.0.1.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 0.2.5-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
-mojoRuntimeVersion = 2.0.0
+mojoRuntimeVersion = 2.0.1
 
 # External dependencies:
 awsLambdaCoreVersion = 1.2.0


### PR DESCRIPTION
We need this update to completely remove capnp-related code from DAI.