### PR TITLE
Return Model's UUID in AWS lambda scorer response.

### DIFF
--- a/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
+++ b/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
@@ -53,7 +53,9 @@ public final class MojoScorer {
         logger.log(String.format("Response has %d rows, %d columns: %s", responseFrame.getNrows(),
                 responseFrame.getNcols(), Arrays.toString(responseFrame.getColumnNames())));
 
-        return responseConverter.apply(responseFrame, request);
+        ScoreResponse response = responseConverter.apply(responseFrame, request);
+        response.id(mojoPipeline.getUuid());
+        return response;
     }
 
     private static MojoPipeline getMojoPipeline(LambdaLogger logger) throws IOException, LicenseException {


### PR DESCRIPTION
This is to support traceability of models.