### PR TITLE
Extract sample request building code to a dedicated class.

### DIFF
--- a/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
+++ b/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
@@ -3,7 +3,11 @@ package ai.h2o.mojos.deploy.aws.lambda;
 
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
-import ai.h2o.mojos.deploy.common.transform.*;
+import ai.h2o.mojos.deploy.common.transform.MojoFrameToResponseConverter;
+import ai.h2o.mojos.deploy.common.transform.RequestChecker;
+import ai.h2o.mojos.deploy.common.transform.RequestToMojoFrameConverter;
+import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
+import ai.h2o.mojos.deploy.common.transform.ScoreRequestFormatException;
 import ai.h2o.mojos.runtime.MojoPipeline;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.lic.LicenseException;

--- a/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
+++ b/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
@@ -3,10 +3,7 @@ package ai.h2o.mojos.deploy.aws.lambda;
 
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
-import ai.h2o.mojos.deploy.common.transform.MojoFrameToResponseConverter;
-import ai.h2o.mojos.deploy.common.transform.RequestChecker;
-import ai.h2o.mojos.deploy.common.transform.RequestToMojoFrameConverter;
-import ai.h2o.mojos.deploy.common.transform.ScoreRequestFormatException;
+import ai.h2o.mojos.deploy.common.transform.*;
 import ai.h2o.mojos.runtime.MojoPipeline;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.lic.LicenseException;
@@ -37,7 +34,7 @@ public final class MojoScorer {
 
     private final RequestToMojoFrameConverter requestConverter = new RequestToMojoFrameConverter();
     private final MojoFrameToResponseConverter responseConverter = new MojoFrameToResponseConverter();
-    private final RequestChecker requestChecker = new RequestChecker();
+    private final RequestChecker requestChecker = new RequestChecker(new SampleRequestBuilder());
 
     public ScoreResponse score(ScoreRequest request, Context context) throws IOException, LicenseException,
             ScoreRequestFormatException {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ subprojects {
                 entry 'junit-jupiter-api'
                 entry 'junit-jupiter-engine'
             }
+            dependencySet(group: 'org.mockito', version: mockitoVersion) {
+                entry 'mockito-core'
+                entry 'mockito-junit-jupiter'
+            }
             dependency group: 'commons-cli', name: 'commons-cli', version: apacheCommonsCliVersion
             dependency group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
         }

--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     compile group: 'ai.h2o', name: 'mojo2-runtime-impl'
 
     testCompile group: 'com.google.truth.extensions', name: 'truth-java8-extension'
+    testCompile group: 'org.mockito', name: 'mockito-core'
+    testCompile group: 'org.mockito', name: 'mockito-junit-jupiter'
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
@@ -2,7 +2,6 @@ package ai.h2o.mojos.deploy.common.transform;
 
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
-import ai.h2o.mojos.runtime.frame.MojoColumn;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 
 import java.util.List;
@@ -13,6 +12,11 @@ import static java.util.Arrays.asList;
  * Checks that the request is of the correct form matching the corresponding mojo pipeline.
  */
 public class RequestChecker {
+    private final SampleRequestBuilder sampleRequestBuilder;
+
+    public RequestChecker(SampleRequestBuilder sampleRequestBuilder) {
+        this.sampleRequestBuilder = sampleRequestBuilder;
+    }
 
     /**
      * Verify that the request is valid and matches the expected {@link MojoFrameMeta}.
@@ -24,7 +28,7 @@ public class RequestChecker {
         if (message == null) {
             return;
         }
-        throw new ScoreRequestFormatException(message, getExampleRequest(expectedMeta));
+        throw new ScoreRequestFormatException(message, sampleRequestBuilder.build(expectedMeta));
     }
 
     private String getProblemMessageOrNull(ScoreRequest scoreRequest, MojoFrameMeta expectedMeta) {
@@ -52,34 +56,5 @@ public class RequestChecker {
             i++;
         }
         return null;
-    }
-
-    private static ScoreRequest getExampleRequest(MojoFrameMeta expectedMeta) {
-        ScoreRequest request = new ScoreRequest();
-        request.setFields(asList(expectedMeta.getColumnNames()));
-        Row row = new Row();
-        for (MojoColumn.Type type : expectedMeta.getColumnTypes()) {
-            row.add(getExampleValue(type));
-        }
-        request.addRowsItem(row);
-        return request;
-    }
-
-    private static String getExampleValue(MojoColumn.Type type) {
-        switch (type) {
-            case Bool:
-                return "true";
-            case Int32:
-            case Int64:
-            case Float32:
-            case Float64:
-                return "0";
-            case Str:
-                return "text";
-            case Time64:
-                return "2018-01-01";
-            default:
-                return "";
-        }
     }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilder.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilder.java
@@ -1,0 +1,47 @@
+package ai.h2o.mojos.deploy.common.transform;
+
+import ai.h2o.mojos.deploy.common.rest.model.Row;
+import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
+import ai.h2o.mojos.runtime.frame.MojoColumn;
+import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+
+import static java.util.Arrays.asList;
+
+/**
+ * SampleRequestBuilder builds sample requests that pass all request validation and get actually scored.
+ * The resulting score is likely to be useless. The purpose is to give the caller an example request to further play
+ * with and fill with actual meaningful data.
+ */
+public class SampleRequestBuilder {
+    /**
+     * Builds a valid {@link ScoreRequest} based on the given mojo input {@link MojoFrameMeta}.
+     */
+    public ScoreRequest build(MojoFrameMeta inputMeta) {
+        ScoreRequest request = new ScoreRequest();
+        request.setFields(asList(inputMeta.getColumnNames()));
+        Row row = new Row();
+        for (MojoColumn.Type type : inputMeta.getColumnTypes()) {
+            row.add(getExampleValue(type));
+        }
+        request.addRowsItem(row);
+        return request;
+    }
+
+    private static String getExampleValue(MojoColumn.Type type) {
+        switch (type) {
+            case Bool:
+                return "true";
+            case Int32:
+            case Int64:
+            case Float32:
+            case Float64:
+                return "0";
+            case Str:
+                return "text";
+            case Time64:
+                return "2018-01-01";
+            default:
+                return "";
+        }
+    }
+}

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
@@ -5,14 +5,25 @@ import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoColumn;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
+@ExtendWith(MockitoExtension.class)
 class RequestCheckerTest {
-    private final RequestChecker checker = new RequestChecker();
+    private final ScoreRequest exampleRequest = new ScoreRequest();
+    @Mock
+    private SampleRequestBuilder sampleRequestBuilder;
+    @InjectMocks
+    private RequestChecker checker;
 
     @Test
     void verifyValidRequest_succeeds() throws ScoreRequestFormatException {
@@ -35,11 +46,13 @@ class RequestCheckerTest {
         // Given
         ScoreRequest request = null;
         MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
+        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
         assertThat(exception.getMessage()).contains("empty");
+        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
     }
 
     @Test
@@ -47,11 +60,13 @@ class RequestCheckerTest {
         // Given
         ScoreRequest request = new ScoreRequest();
         MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
+        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
         assertThat(exception.getMessage()).contains("empty");
+        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
     }
 
     @Test
@@ -62,11 +77,13 @@ class RequestCheckerTest {
         MojoFrameMeta expectedMeta = new MojoFrameMeta(
                 new String[]{"field1"},
                 new MojoColumn.Type[]{MojoColumn.Type.Str});
+        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
         assertThat(exception.getMessage()).contains("fields cannot be empty");
+        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
     }
 
     @Test
@@ -77,11 +94,13 @@ class RequestCheckerTest {
         MojoFrameMeta expectedMeta = new MojoFrameMeta(
                 new String[]{"field1"},
                 new MojoColumn.Type[]{MojoColumn.Type.Str});
+        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
         assertThat(exception.getMessage()).contains("rows cannot be empty");
+        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
     }
 
     @Test
@@ -93,11 +112,13 @@ class RequestCheckerTest {
         MojoFrameMeta expectedMeta = new MojoFrameMeta(
                 new String[]{"different_fields"},
                 new MojoColumn.Type[]{MojoColumn.Type.Str});
+        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
         assertThat(exception.getMessage()).contains("fields don't contain all");
+        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
     }
 
     @Test
@@ -109,11 +130,13 @@ class RequestCheckerTest {
         MojoFrameMeta expectedMeta = new MojoFrameMeta(
                 new String[]{"field1", "field2"},
                 new MojoColumn.Type[]{MojoColumn.Type.Str, MojoColumn.Type.Str});
+        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
         assertThat(exception.getMessage()).contains("fields don't contain all");
+        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
     }
 
     @Test
@@ -143,11 +166,13 @@ class RequestCheckerTest {
         MojoFrameMeta expectedMeta = new MojoFrameMeta(
                 new String[]{"field1"},
                 new MojoColumn.Type[]{MojoColumn.Type.Str});
+        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
         // When & then
         ScoreRequestFormatException exception =
                 assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
         assertThat(exception.getMessage()).contains("row 1");
+        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
     }
 
     private static Row toRow(String... values) {

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilderTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilderTest.java
@@ -1,0 +1,76 @@
+package ai.h2o.mojos.deploy.common.transform;
+
+import ai.h2o.mojos.deploy.common.rest.model.Row;
+import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
+import ai.h2o.mojos.runtime.frame.MojoColumn;
+import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+class SampleRequestBuilderTest {
+
+    private final SampleRequestBuilder builder = new SampleRequestBuilder();
+
+    @Test
+    void build_EmptyMeta() {
+        // Given
+        MojoFrameMeta inputMeta = new MojoFrameMeta(new String[]{}, new MojoColumn.Type[]{});
+
+        // When
+        ScoreRequest result = builder.build(inputMeta);
+
+        // Then
+        ScoreRequest expected = new ScoreRequest();
+        expected.fields(emptyList());
+        expected.addRowsItem(asRow());
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void build_OneField() {
+        // Given
+        MojoFrameMeta inputMeta = new MojoFrameMeta(
+                new String[]{"field"},
+                new MojoColumn.Type[]{MojoColumn.Type.Str});
+
+        // When
+        ScoreRequest result = builder.build(inputMeta);
+
+        // Then
+        ScoreRequest expected = new ScoreRequest();
+        expected.addFieldsItem("field");
+        expected.addRowsItem(asRow("text"));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void build_AllTypes() {
+        // Given
+        MojoColumn.Type[] types = {
+                MojoColumn.Type.Str, MojoColumn.Type.Float32, MojoColumn.Type.Float64, MojoColumn.Type.Bool,
+                MojoColumn.Type.Int32, MojoColumn.Type.Int64, MojoColumn.Type.Time64};
+        String[] columns = Stream.of(types).map(Object::toString).toArray(String[]::new);
+        MojoFrameMeta inputMeta = new MojoFrameMeta(columns, types);
+
+        // When
+        ScoreRequest result = builder.build(inputMeta);
+
+        // Then
+        ScoreRequest expected = new ScoreRequest();
+        expected.fields(asList(columns));
+        expected.addRowsItem((asRow("text", "0", "0", "true", "0", "0", "2018-01-01")));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    private static Row asRow(String... values) {
+        Row row = new Row();
+        row.addAll(asList(values));
+        return row;
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ awsSdkS3Version = 1.11.445
 javaxAnnotationVersion = 1.3.2
 gsonVersion = 2.8.5
 jupiterVersion = 5.3.1
+mockitoVersion = 3.0.0
 springFoxVersion = 2.9.2
 swaggerCodegenVersion = 3.0.0
 swaggerCoreVersion = 2.0.5


### PR DESCRIPTION
Moves the exiting code and adds tests.
This is a step towards adding a dedicated endpoint which would return a sample scoring request discussed in h2oai/h2oai-serving#251.