### PR TITLE
 Add local rest server endpoint for getting a sample request.

### DIFF
--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -58,6 +58,28 @@ paths:
             $ref: '#/definitions/Model'
         '404':
           description: 'Model not found, please verify model id'
+  '/models/{id}/sample_request':
+    get:
+      tags:
+        - models
+      summary: sample scoring request
+      description: builds a sample scoring request that would pass all validations
+      operationId: getSampleRequest
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: unique model indetifier
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/ScoreRequest'
+        '404':
+          description: 'Model not found, please verify model id'
   '/models/{id}/score':
     post:
       tags:

--- a/local-rest-scorer/README.md
+++ b/local-rest-scorer/README.md
@@ -16,7 +16,7 @@ The resulting executable jar is located in the `build/libs` folder.
 To run the local scorer, you can either use `bootRun` gradle task or run directly the executable jar:
 
 ```bash
-$ java -Dmojo.path={PATH_TO_MOJO_PIPELINE} -jar build/libs/local-rest-scorer-{YOUR_CURRENT_VERSION}.jar
+java -Dmojo.path={PATH_TO_MOJO_PIPELINE} -jar build/libs/local-rest-scorer-{YOUR_CURRENT_VERSION}.jar
 ``` 
 
 
@@ -25,7 +25,7 @@ $ java -Dmojo.path={PATH_TO_MOJO_PIPELINE} -jar build/libs/local-rest-scorer-{YO
 To test the endpoint, send a request to http://localhost:8080 as follows:
 
 ```bash
-$ curl \
+curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d @test.json http://localhost:8080/models/{UUID_OF_YOUR_MOJO_PIPELINE}/score
@@ -102,7 +102,7 @@ The expected response should follow this structure, but the actual values may di
 Alternatively, you can score an existing file on the local filesystem using `GET` request to the same endpoint:
 
 ```bash
-$ curl \
+curl \
     -X GET \
     http://localhost:8080/models/{UUID_OF_YOUR_MOJO_PIPELINE}/score/?file=/tmp/test.csv
 ```
@@ -111,10 +111,23 @@ This expects a CSV file `/tmp/test.csv` to exist on the machine where the scorer
 over HTTP).
 
 
+### Get Example Request
+
+The scorer can also provide an example request that would pass all validations.
+This way, users can quickly get an example scoring request to send to the scorer to test it.
+This request can be further filled with meaningful input values.
+
+```bash
+curl \
+    -X GET \
+    http://localhost:8080/models/{UUID_OF_YOUR_MOJO_PIPELINE}/sample_request
+```
+
+The resulting JSON is a valid input for the POST `/score` request.
+
 ### API Inspection
 
 You can use SpringFox endpoints that allow both programmatic and manual inspection of the API:
 
 * Swagger JSON representation for programmatic access: http://localhost:8080/v2/api-docs.
 * The UI for manual API inspection: http://localhost:8080/swagger-ui.html.
-

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
@@ -4,6 +4,7 @@ import ai.h2o.mojos.deploy.common.transform.CsvToMojoFrameConverter;
 import ai.h2o.mojos.deploy.common.transform.MojoFrameToResponseConverter;
 import ai.h2o.mojos.deploy.common.transform.MojoPipelineToModelInfoConverter;
 import ai.h2o.mojos.deploy.common.transform.RequestToMojoFrameConverter;
+import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,5 +28,10 @@ class ScorerConfiguration {
     @Bean
     public CsvToMojoFrameConverter csvConverter() {
         return new CsvToMojoFrameConverter();
+    }
+
+    @Bean
+    public SampleRequestBuilder sampleRequestBuilder() {
+        return new SampleRequestBuilder();
     }
 }

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/MojoScorer.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/MojoScorer.java
@@ -90,6 +90,10 @@ class MojoScorer {
         return pipeline.getUuid();
     }
 
+    MojoPipeline getPipeline() {
+        return pipeline;
+    }
+
     Model getModelInfo() {
         return modelInfoConverter.apply(pipeline);
     }


### PR DESCRIPTION
This is meant for the users to have a simple way to get a sample scoring request that would pass the validation and result in a (probably nonsensical) score.
As discussed in h2oai/h2oai-serving#251, this may be used by the Model Manager UI as a means to provide an example `curl` snippet to test the scorer.