### PR TITLE
Add input content-type JSON to the Swagger API.

### DIFF
--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -65,6 +65,8 @@ paths:
       summary: score a model
       description: score a model
       operationId: getScore
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:


### PR DESCRIPTION
Apart from being more specific (other content-types fail anyway), this fixes the Swagger UI to allow sending sample requests with it.