### PR TITLE
Use google-java-format formatting.

### DIFF
--- a/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/ApiGatewayWrapper.java
+++ b/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/ApiGatewayWrapper.java
@@ -11,65 +11,75 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
-import org.apache.http.HttpStatus;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import org.apache.http.HttpStatus;
 
 /**
  * Wraps {@link MojoScorer} so that it can be called via the AWS API gateway.
  *
- * <p>Note that AWS API Gateway strictly mandates the input and output formats that we need to adhere to here.
- * In addition, this class does error handling.
+ * <p>Note that AWS API Gateway strictly mandates the input and output formats that we need to
+ * adhere to here. In addition, this class does error handling.
  *
- * @see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html">
- * Build an API Gateway API with Lambda Proxy Integration</a>
+ * @see <a
+ *     href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html">
+ *     Build an API Gateway API with Lambda Proxy Integration</a>
  */
-public class ApiGatewayWrapper implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    private final MojoScorer mojoScorer = new MojoScorer();
+public class ApiGatewayWrapper
+    implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+  private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+  private final MojoScorer mojoScorer = new MojoScorer();
 
-    @Override
-    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
-        try {
-            ScoreRequest scoreRequest = gson.fromJson(input.getBody(), ScoreRequest.class);
-            ScoreResponse scoreResponse = mojoScorer.score(scoreRequest, context);
-            return toSuccessResponse(gson.toJson(scoreResponse));
-        } catch (JsonSyntaxException e) {
-            return toErrorResponse(HttpStatus.SC_BAD_REQUEST, "Malformed JSON request", e);
-        } catch (ScoreRequestFormatException e) {
-            return toRequestFormatResponse(e);
-        } catch (IOException e) {
-            return toErrorResponse(HttpStatus.SC_NOT_FOUND, "Mojo pipeline file not found", e);
-        } catch (LicenseException e) {
-            return toErrorResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "Could not find a valid license file", e);
-        } catch (Exception e) {
-            return toErrorResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR, "Unexpected error while scoring", e);
-        }
+  @Override
+  public APIGatewayProxyResponseEvent handleRequest(
+      APIGatewayProxyRequestEvent input, Context context) {
+    try {
+      ScoreRequest scoreRequest = gson.fromJson(input.getBody(), ScoreRequest.class);
+      ScoreResponse scoreResponse = mojoScorer.score(scoreRequest, context);
+      return toSuccessResponse(gson.toJson(scoreResponse));
+    } catch (JsonSyntaxException e) {
+      return toErrorResponse(HttpStatus.SC_BAD_REQUEST, "Malformed JSON request", e);
+    } catch (ScoreRequestFormatException e) {
+      return toRequestFormatResponse(e);
+    } catch (IOException e) {
+      return toErrorResponse(HttpStatus.SC_NOT_FOUND, "Mojo pipeline file not found", e);
+    } catch (LicenseException e) {
+      return toErrorResponse(
+          HttpStatus.SC_SERVICE_UNAVAILABLE, "Could not find a valid license file", e);
+    } catch (Exception e) {
+      return toErrorResponse(
+          HttpStatus.SC_INTERNAL_SERVER_ERROR, "Unexpected error while scoring", e);
     }
+  }
 
-    private static APIGatewayProxyResponseEvent toErrorResponse(int statusCode, String message, Exception exception) {
-        String exceptionAsString = getExceptionAsString(exception);
-        return new APIGatewayProxyResponseEvent().withStatusCode(statusCode).withBody(
-                String.format("%s\n\nError details:\n%s\n", message, exceptionAsString));
-    }
+  private static APIGatewayProxyResponseEvent toErrorResponse(
+      int statusCode, String message, Exception exception) {
+    String exceptionAsString = getExceptionAsString(exception);
+    return new APIGatewayProxyResponseEvent()
+        .withStatusCode(statusCode)
+        .withBody(String.format("%s\n\nError details:\n%s\n", message, exceptionAsString));
+  }
 
-    private static String getExceptionAsString(Exception exception) {
-        StringWriter sw = new StringWriter();
-        exception.printStackTrace(new PrintWriter(sw));
-        return sw.toString();
-    }
+  private static String getExceptionAsString(Exception exception) {
+    StringWriter sw = new StringWriter();
+    exception.printStackTrace(new PrintWriter(sw));
+    return sw.toString();
+  }
 
-    private APIGatewayProxyResponseEvent toRequestFormatResponse(ScoreRequestFormatException exception) {
-        String exceptionAsString = getExceptionAsString(exception);
-        String example = gson.toJson(exception.getExampleRequest());
-        return new APIGatewayProxyResponseEvent().withStatusCode(HttpStatus.SC_BAD_REQUEST).withBody(
-                String.format("Malformed scoring request.\n\nError details:\n%s\n\nExample request:\n%s\n",
-                        exceptionAsString, example));
-    }
+  private APIGatewayProxyResponseEvent toRequestFormatResponse(
+      ScoreRequestFormatException exception) {
+    String exceptionAsString = getExceptionAsString(exception);
+    String example = gson.toJson(exception.getExampleRequest());
+    return new APIGatewayProxyResponseEvent()
+        .withStatusCode(HttpStatus.SC_BAD_REQUEST)
+        .withBody(
+            String.format(
+                "Malformed scoring request.\n\nError details:\n%s\n\nExample request:\n%s\n",
+                exceptionAsString, example));
+  }
 
-    private static APIGatewayProxyResponseEvent toSuccessResponse(String body) {
-        return new APIGatewayProxyResponseEvent().withStatusCode(HttpStatus.SC_OK).withBody(body);
-    }
+  private static APIGatewayProxyResponseEvent toSuccessResponse(String body) {
+    return new APIGatewayProxyResponseEvent().withStatusCode(HttpStatus.SC_OK).withBody(body);
+  }
 }

--- a/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
+++ b/aws-lambda-scorer/lambda-template/src/main/java/ai/h2o/mojos/deploy/aws/lambda/MojoScorer.java
@@ -1,4 +1,3 @@
-
 package ai.h2o.mojos.deploy.aws.lambda;
 
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
@@ -18,7 +17,6 @@ import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -30,55 +28,67 @@ import java.util.Arrays;
  * e.g., the location of the mojo file in AWS S3.
  */
 public final class MojoScorer {
-    private static final String DEPLOYMENT_S3_BUCKET_NAME = System.getenv("DEPLOYMENT_S3_BUCKET_NAME");
-    private static final String MOJO_S3_OBJECT_KEY = System.getenv("MOJO_S3_OBJECT_KEY");
-    private static final AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
-    private static final Object pipelineLock = new Object();
-    private static MojoPipeline pipeline;
+  private static final String DEPLOYMENT_S3_BUCKET_NAME =
+      System.getenv("DEPLOYMENT_S3_BUCKET_NAME");
+  private static final String MOJO_S3_OBJECT_KEY = System.getenv("MOJO_S3_OBJECT_KEY");
+  private static final AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
+  private static final Object pipelineLock = new Object();
+  private static MojoPipeline pipeline;
 
-    private final RequestToMojoFrameConverter requestConverter = new RequestToMojoFrameConverter();
-    private final MojoFrameToResponseConverter responseConverter = new MojoFrameToResponseConverter();
-    private final RequestChecker requestChecker = new RequestChecker(new SampleRequestBuilder());
+  private final RequestToMojoFrameConverter requestConverter = new RequestToMojoFrameConverter();
+  private final MojoFrameToResponseConverter responseConverter = new MojoFrameToResponseConverter();
+  private final RequestChecker requestChecker = new RequestChecker(new SampleRequestBuilder());
 
-    public ScoreResponse score(ScoreRequest request, Context context) throws IOException, LicenseException,
-            ScoreRequestFormatException {
-        LambdaLogger logger = context.getLogger();
-        logger.log("Got scoring request");
-        MojoPipeline mojoPipeline = getMojoPipeline(logger);
-        requestChecker.verify(request, mojoPipeline.getInputMeta());
-        logger.log("Scoring request verified");
-        MojoFrame requestFrame = requestConverter.apply(request, mojoPipeline.getInputFrameBuilder());
-        logger.log(String.format("Input has %d rows, %d columns: %s", requestFrame.getNrows(), requestFrame.getNcols(),
-                Arrays.toString(requestFrame.getColumnNames())));
-        MojoFrame responseFrame = mojoPipeline.transform(requestFrame);
-        logger.log(String.format("Response has %d rows, %d columns: %s", responseFrame.getNrows(),
-                responseFrame.getNcols(), Arrays.toString(responseFrame.getColumnNames())));
+  public ScoreResponse score(ScoreRequest request, Context context)
+      throws IOException, LicenseException, ScoreRequestFormatException {
+    LambdaLogger logger = context.getLogger();
+    logger.log("Got scoring request");
+    MojoPipeline mojoPipeline = getMojoPipeline(logger);
+    requestChecker.verify(request, mojoPipeline.getInputMeta());
+    logger.log("Scoring request verified");
+    MojoFrame requestFrame = requestConverter.apply(request, mojoPipeline.getInputFrameBuilder());
+    logger.log(
+        String.format(
+            "Input has %d rows, %d columns: %s",
+            requestFrame.getNrows(),
+            requestFrame.getNcols(),
+            Arrays.toString(requestFrame.getColumnNames())));
+    MojoFrame responseFrame = mojoPipeline.transform(requestFrame);
+    logger.log(
+        String.format(
+            "Response has %d rows, %d columns: %s",
+            responseFrame.getNrows(),
+            responseFrame.getNcols(),
+            Arrays.toString(responseFrame.getColumnNames())));
 
-        ScoreResponse response = responseConverter.apply(responseFrame, request);
-        response.id(mojoPipeline.getUuid());
-        return response;
+    ScoreResponse response = responseConverter.apply(responseFrame, request);
+    response.id(mojoPipeline.getUuid());
+    return response;
+  }
+
+  private static MojoPipeline getMojoPipeline(LambdaLogger logger)
+      throws IOException, LicenseException {
+    synchronized (pipelineLock) {
+      if (pipeline == null) {
+        pipeline = loadMojoPipelineFromS3(logger);
+      }
+      return pipeline;
     }
+  }
 
-    private static MojoPipeline getMojoPipeline(LambdaLogger logger) throws IOException, LicenseException {
-        synchronized (pipelineLock) {
-            if (pipeline == null) {
-                pipeline = loadMojoPipelineFromS3(logger);
-            }
-            return pipeline;
-        }
+  private static MojoPipeline loadMojoPipelineFromS3(LambdaLogger logger)
+      throws IOException, LicenseException {
+    try (S3Object s3Object = s3Client.getObject(DEPLOYMENT_S3_BUCKET_NAME, MOJO_S3_OBJECT_KEY);
+        InputStream mojoInput = s3Object.getObjectContent()) {
+      logger.log(
+          String.format(
+              "Loading Mojo pipeline from S3 object %s/%s",
+              DEPLOYMENT_S3_BUCKET_NAME, MOJO_S3_OBJECT_KEY));
+      MojoReaderBackend mojoReaderBackend =
+          MojoPipelineReaderBackendFactory.createReaderBackend(mojoInput);
+      MojoPipeline mojoPipeline = MojoPipeline.loadFrom(mojoReaderBackend);
+      logger.log(String.format("Mojo pipeline successfully loaded (%s).", mojoPipeline.getUuid()));
+      return mojoPipeline;
     }
-
-    private static MojoPipeline loadMojoPipelineFromS3(LambdaLogger logger) throws IOException, LicenseException {
-        try (
-                S3Object s3Object = s3Client.getObject(DEPLOYMENT_S3_BUCKET_NAME, MOJO_S3_OBJECT_KEY);
-                InputStream mojoInput = s3Object.getObjectContent()
-        ) {
-            logger.log(String.format("Loading Mojo pipeline from S3 object %s/%s", DEPLOYMENT_S3_BUCKET_NAME,
-                    MOJO_S3_OBJECT_KEY));
-            MojoReaderBackend mojoReaderBackend = MojoPipelineReaderBackendFactory.createReaderBackend(mojoInput);
-            MojoPipeline mojoPipeline = MojoPipeline.loadFrom(mojoReaderBackend);
-            logger.log(String.format("Mojo pipeline successfully loaded (%s).", mojoPipeline.getUuid()));
-            return mojoPipeline;
-        }
-    }
+  }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/CsvToMojoFrameConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/CsvToMojoFrameConverter.java
@@ -4,32 +4,31 @@ import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
 import ai.h2o.mojos.runtime.utils.SimpleCSV;
-
 import java.io.IOException;
 import java.io.InputStream;
 
-/**
- * Converts the CSV from {@link InputStream} to the {@link MojoFrame} for scoring.
- */
+/** Converts the CSV from {@link InputStream} to the {@link MojoFrame} for scoring. */
 public class CsvToMojoFrameConverter {
-    public MojoFrame apply(InputStream inputStream, MojoFrameBuilder frameBuilder) throws IOException {
-        MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
-        SimpleCSV csv = SimpleCSV.read(inputStream);
-        String[] labels = csv.getLabels();
-        if (labels.length != rowBuilder.size()) {
-            throw new IllegalArgumentException(
-                    String.format("Mismatch between column counts of CSV file and the mojo (csv=%d, mojo=%d).",
-                            labels.length, rowBuilder.size()));
-        }
-
-        String[][] data = csv.getData();
-        for (String[] row : data) {
-            for (int c = 0; c < row.length; c++) {
-                rowBuilder.setValue(labels[c], row[c]);
-            }
-            // Reuse the builder.
-            rowBuilder = frameBuilder.addRow(rowBuilder);
-        }
-        return frameBuilder.toMojoFrame();
+  public MojoFrame apply(InputStream inputStream, MojoFrameBuilder frameBuilder)
+      throws IOException {
+    MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
+    SimpleCSV csv = SimpleCSV.read(inputStream);
+    String[] labels = csv.getLabels();
+    if (labels.length != rowBuilder.size()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Mismatch between column counts of CSV file and the mojo (csv=%d, mojo=%d).",
+              labels.length, rowBuilder.size()));
     }
+
+    String[][] data = csv.getData();
+    for (String[] row : data) {
+      for (int c = 0; c < row.length; c++) {
+        rowBuilder.setValue(labels[c], row[c]);
+      }
+      // Reuse the builder.
+      rowBuilder = frameBuilder.addRow(rowBuilder);
+    }
+    return frameBuilder.toMojoFrame();
+  }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
@@ -1,10 +1,11 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static java.util.Collections.emptyList;
+
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -13,53 +14,55 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
-
 /**
- * Converts the resulting predicted {@link MojoFrame} into the API response object {@link ScoreResponse}.
+ * Converts the resulting predicted {@link MojoFrame} into the API response object {@link
+ * ScoreResponse}.
  */
-public class MojoFrameToResponseConverter implements BiFunction<MojoFrame, ScoreRequest, ScoreResponse> {
+public class MojoFrameToResponseConverter
+    implements BiFunction<MojoFrame, ScoreRequest, ScoreResponse> {
 
-    @Override
-    public ScoreResponse apply(MojoFrame mojoFrame, ScoreRequest scoreRequest) {
-        List<Row> outputRows = Stream.generate(Row::new).limit(mojoFrame.getNrows()).collect(Collectors.toList());
-        copyFilteredInputFields(scoreRequest, outputRows);
-        copyResultFields(mojoFrame, outputRows);
+  @Override
+  public ScoreResponse apply(MojoFrame mojoFrame, ScoreRequest scoreRequest) {
+    List<Row> outputRows =
+        Stream.generate(Row::new).limit(mojoFrame.getNrows()).collect(Collectors.toList());
+    copyFilteredInputFields(scoreRequest, outputRows);
+    copyResultFields(mojoFrame, outputRows);
 
-        ScoreResponse response = new ScoreResponse();
-        response.setScore(outputRows);
-        return response;
+    ScoreResponse response = new ScoreResponse();
+    response.setScore(outputRows);
+    return response;
+  }
+
+  private static void copyFilteredInputFields(ScoreRequest scoreRequest, List<Row> outputRows) {
+    Set<String> includedFields =
+        new HashSet<>(
+            Optional.ofNullable(scoreRequest.getIncludeFieldsInOutput()).orElse(emptyList()));
+    if (includedFields.isEmpty()) {
+      return;
     }
-
-    private static void copyFilteredInputFields(ScoreRequest scoreRequest, List<Row> outputRows) {
-        Set<String> includedFields = new HashSet<>(
-                Optional.ofNullable(scoreRequest.getIncludeFieldsInOutput()).orElse(emptyList()));
-        if (includedFields.isEmpty()) {
-            return;
+    List<Row> inputRows = scoreRequest.getRows();
+    for (int row = 0; row < outputRows.size(); row++) {
+      Row inputRow = inputRows.get(row);
+      Row outputRow = outputRows.get(row);
+      List<String> inputFields = scoreRequest.getFields();
+      for (int col = 0; col < inputFields.size(); col++) {
+        if (includedFields.contains(inputFields.get(col))) {
+          outputRow.add(inputRow.get(col));
         }
-        List<Row> inputRows = scoreRequest.getRows();
-        for (int row = 0; row < outputRows.size(); row++) {
-            Row inputRow = inputRows.get(row);
-            Row outputRow = outputRows.get(row);
-            List<String> inputFields = scoreRequest.getFields();
-            for (int col = 0; col < inputFields.size(); col++) {
-                if (includedFields.contains(inputFields.get(col))) {
-                    outputRow.add(inputRow.get(col));
-                }
-            }
-        }
+      }
     }
+  }
 
-    private static void copyResultFields(MojoFrame mojoFrame, List<Row> outputRows) {
-        String[][] outputColumns = new String[mojoFrame.getNcols()][];
-        for (int col = 0; col < mojoFrame.getNcols(); col++) {
-            outputColumns[col] = mojoFrame.getColumn(col).getDataAsStrings();
-        }
-        for (int row = 0; row < mojoFrame.getNrows(); row++) {
-            Row outputRow = outputRows.get(row);
-            for (String[] resultColumn : outputColumns) {
-                outputRow.add(resultColumn[row]);
-            }
-        }
+  private static void copyResultFields(MojoFrame mojoFrame, List<Row> outputRows) {
+    String[][] outputColumns = new String[mojoFrame.getNcols()][];
+    for (int col = 0; col < mojoFrame.getNcols(); col++) {
+      outputColumns[col] = mojoFrame.getColumn(col).getDataAsStrings();
     }
+    for (int row = 0; row < mojoFrame.getNrows(); row++) {
+      Row outputRow = outputRows.get(row);
+      for (String[] resultColumn : outputColumns) {
+        outputRow.add(resultColumn[row]);
+      }
+    }
+  }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverter.java
@@ -3,48 +3,43 @@ package ai.h2o.mojos.deploy.common.transform;
 import ai.h2o.mojos.deploy.common.rest.model.DataField;
 import ai.h2o.mojos.deploy.common.rest.model.Model;
 import ai.h2o.mojos.deploy.common.rest.model.ModelSchema;
-import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
 import ai.h2o.mojos.runtime.MojoPipeline;
 import ai.h2o.mojos.runtime.frame.MojoColumn.Type;
-import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-/**
- * Converts the {@link MojoPipeline} schema to the REST API Model information {@link Model}.
- */
+/** Converts the {@link MojoPipeline} schema to the REST API Model information {@link Model}. */
 public class MojoPipelineToModelInfoConverter implements Function<MojoPipeline, Model> {
 
-    @Override
-    public Model apply(MojoPipeline pipeline) {
-        Model model = new Model();
-        model.setId(pipeline.getUuid());
-        model.setSchema(extractSchema(pipeline));
-        return model;
-    }
+  @Override
+  public Model apply(MojoPipeline pipeline) {
+    Model model = new Model();
+    model.setId(pipeline.getUuid());
+    model.setSchema(extractSchema(pipeline));
+    return model;
+  }
 
-    private static ModelSchema extractSchema(MojoPipeline pipeline) {
-        ModelSchema schema = new ModelSchema();
-        schema.inputFields(extractFields(pipeline.getInputMeta()));
-        schema.outputFields(extractFields(pipeline.getOutputMeta()));
-        return schema;
-    }
+  private static ModelSchema extractSchema(MojoPipeline pipeline) {
+    ModelSchema schema = new ModelSchema();
+    schema.inputFields(extractFields(pipeline.getInputMeta()));
+    schema.outputFields(extractFields(pipeline.getOutputMeta()));
+    return schema;
+  }
 
-    private static List<DataField> extractFields(MojoFrameMeta meta) {
-        List<DataField> fields = new ArrayList<>(meta.size());
-        for (int i = 0; i < meta.size(); i++) {
-            DataField dataField = new DataField();
-            dataField.name(meta.getColumnName(i));
-            dataField.dataType(mojoTypeToDataType(meta.getColumnType(i)));
-            fields.add(dataField);
-        }
-        return fields;
+  private static List<DataField> extractFields(MojoFrameMeta meta) {
+    List<DataField> fields = new ArrayList<>(meta.size());
+    for (int i = 0; i < meta.size(); i++) {
+      DataField dataField = new DataField();
+      dataField.name(meta.getColumnName(i));
+      dataField.dataType(mojoTypeToDataType(meta.getColumnType(i)));
+      fields.add(dataField);
     }
+    return fields;
+  }
 
-    private static DataField.DataTypeEnum mojoTypeToDataType(Type columnType) {
-        return DataField.DataTypeEnum.fromValue(columnType.toString());
-    }
+  private static DataField.DataTypeEnum mojoTypeToDataType(Type columnType) {
+    return DataField.DataTypeEnum.fromValue(columnType.toString());
+  }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestChecker.java
@@ -1,60 +1,59 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static java.util.Arrays.asList;
+
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
-
 import java.util.List;
 
-import static java.util.Arrays.asList;
-
-/**
- * Checks that the request is of the correct form matching the corresponding mojo pipeline.
- */
+/** Checks that the request is of the correct form matching the corresponding mojo pipeline. */
 public class RequestChecker {
-    private final SampleRequestBuilder sampleRequestBuilder;
+  private final SampleRequestBuilder sampleRequestBuilder;
 
-    public RequestChecker(SampleRequestBuilder sampleRequestBuilder) {
-        this.sampleRequestBuilder = sampleRequestBuilder;
-    }
+  public RequestChecker(SampleRequestBuilder sampleRequestBuilder) {
+    this.sampleRequestBuilder = sampleRequestBuilder;
+  }
 
-    /**
-     * Verify that the request is valid and matches the expected {@link MojoFrameMeta}.
-     *
-     * @throws ScoreRequestFormatException on any issues.
-     */
-    public void verify(ScoreRequest scoreRequest, MojoFrameMeta expectedMeta) throws ScoreRequestFormatException {
-        String message = getProblemMessageOrNull(scoreRequest, expectedMeta);
-        if (message == null) {
-            return;
-        }
-        throw new ScoreRequestFormatException(message, sampleRequestBuilder.build(expectedMeta));
+  /**
+   * Verify that the request is valid and matches the expected {@link MojoFrameMeta}.
+   *
+   * @throws ScoreRequestFormatException on any issues.
+   */
+  public void verify(ScoreRequest scoreRequest, MojoFrameMeta expectedMeta)
+      throws ScoreRequestFormatException {
+    String message = getProblemMessageOrNull(scoreRequest, expectedMeta);
+    if (message == null) {
+      return;
     }
+    throw new ScoreRequestFormatException(message, sampleRequestBuilder.build(expectedMeta));
+  }
 
-    private String getProblemMessageOrNull(ScoreRequest scoreRequest, MojoFrameMeta expectedMeta) {
-        if (scoreRequest == null) {
-            return "Request cannot be empty";
-        }
-        List<String> fields = scoreRequest.getFields();
-        if (fields == null || fields.isEmpty()) {
-            return "List of input fields cannot be empty";
-        }
-        List<Row> rows = scoreRequest.getRows();
-        if (rows == null || rows.isEmpty()) {
-            return "List of input data rows cannot be empty";
-        }
-        List<String> expectedFields = asList(expectedMeta.getColumnNames());
-        if (!fields.containsAll(expectedFields)) {
-            return String.format("Input fields don't contain all the Mojo fields, expected %s actual %s",
-                    expectedFields.toString(), fields.toString());
-        }
-        int i = 0;
-        for (Row row : scoreRequest.getRows()) {
-            if (row.size() != fields.size()) {
-                return String.format("Not enough elements in row %d (zero-indexed)", i);
-            }
-            i++;
-        }
-        return null;
+  private String getProblemMessageOrNull(ScoreRequest scoreRequest, MojoFrameMeta expectedMeta) {
+    if (scoreRequest == null) {
+      return "Request cannot be empty";
     }
+    List<String> fields = scoreRequest.getFields();
+    if (fields == null || fields.isEmpty()) {
+      return "List of input fields cannot be empty";
+    }
+    List<Row> rows = scoreRequest.getRows();
+    if (rows == null || rows.isEmpty()) {
+      return "List of input data rows cannot be empty";
+    }
+    List<String> expectedFields = asList(expectedMeta.getColumnNames());
+    if (!fields.containsAll(expectedFields)) {
+      return String.format(
+          "Input fields don't contain all the Mojo fields, expected %s actual %s",
+          expectedFields.toString(), fields.toString());
+    }
+    int i = 0;
+    for (Row row : scoreRequest.getRows()) {
+      if (row.size() != fields.size()) {
+        return String.format("Not enough elements in row %d (zero-indexed)", i);
+      }
+      i++;
+    }
+    return null;
+  }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestToMojoFrameConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/RequestToMojoFrameConverter.java
@@ -5,28 +5,28 @@ import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
-
 import java.util.List;
 import java.util.function.BiFunction;
 
 /**
  * Converts the original API request object {@link ScoreRequest} into the input {@link MojoFrame}.
  */
-public class RequestToMojoFrameConverter implements BiFunction<ScoreRequest, MojoFrameBuilder, MojoFrame> {
-    @Override
-    public MojoFrame apply(ScoreRequest scoreRequest, MojoFrameBuilder frameBuilder) {
-        List<String> fields = scoreRequest.getFields();
+public class RequestToMojoFrameConverter
+    implements BiFunction<ScoreRequest, MojoFrameBuilder, MojoFrame> {
+  @Override
+  public MojoFrame apply(ScoreRequest scoreRequest, MojoFrameBuilder frameBuilder) {
+    List<String> fields = scoreRequest.getFields();
 
-        if (scoreRequest.getRows() != null) {
-            for (Row row : scoreRequest.getRows()) {
-                MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
-                for (int i = 0; i < row.size(); i++) {
-                    rowBuilder.setValue(fields.get(i), row.get(i));
-                }
-                frameBuilder.addRow(rowBuilder);
-            }
+    if (scoreRequest.getRows() != null) {
+      for (Row row : scoreRequest.getRows()) {
+        MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
+        for (int i = 0; i < row.size(); i++) {
+          rowBuilder.setValue(fields.get(i), row.get(i));
         }
-
-        return frameBuilder.toMojoFrame();
+        frameBuilder.addRow(rowBuilder);
+      }
     }
+
+    return frameBuilder.toMojoFrame();
+  }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilder.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilder.java
@@ -1,47 +1,45 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static java.util.Arrays.asList;
+
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoColumn;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 
-import static java.util.Arrays.asList;
-
 /**
- * SampleRequestBuilder builds sample requests that pass all request validation and get actually scored.
- * The resulting score is likely to be useless. The purpose is to give the caller an example request to further play
- * with and fill with actual meaningful data.
+ * SampleRequestBuilder builds sample requests that pass all request validation and get actually
+ * scored. The resulting score is likely to be useless. The purpose is to give the caller an example
+ * request to further play with and fill with actual meaningful data.
  */
 public class SampleRequestBuilder {
-    /**
-     * Builds a valid {@link ScoreRequest} based on the given mojo input {@link MojoFrameMeta}.
-     */
-    public ScoreRequest build(MojoFrameMeta inputMeta) {
-        ScoreRequest request = new ScoreRequest();
-        request.setFields(asList(inputMeta.getColumnNames()));
-        Row row = new Row();
-        for (MojoColumn.Type type : inputMeta.getColumnTypes()) {
-            row.add(getExampleValue(type));
-        }
-        request.addRowsItem(row);
-        return request;
+  /** Builds a valid {@link ScoreRequest} based on the given mojo input {@link MojoFrameMeta}. */
+  public ScoreRequest build(MojoFrameMeta inputMeta) {
+    ScoreRequest request = new ScoreRequest();
+    request.setFields(asList(inputMeta.getColumnNames()));
+    Row row = new Row();
+    for (MojoColumn.Type type : inputMeta.getColumnTypes()) {
+      row.add(getExampleValue(type));
     }
+    request.addRowsItem(row);
+    return request;
+  }
 
-    private static String getExampleValue(MojoColumn.Type type) {
-        switch (type) {
-            case Bool:
-                return "true";
-            case Int32:
-            case Int64:
-            case Float32:
-            case Float64:
-                return "0";
-            case Str:
-                return "text";
-            case Time64:
-                return "2018-01-01";
-            default:
-                return "";
-        }
+  private static String getExampleValue(MojoColumn.Type type) {
+    switch (type) {
+      case Bool:
+        return "true";
+      case Int32:
+      case Int64:
+      case Float32:
+      case Float64:
+        return "0";
+      case Str:
+        return "text";
+      case Time64:
+        return "2018-01-01";
+      default:
+        return "";
     }
+  }
 }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/ScoreRequestFormatException.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/ScoreRequestFormatException.java
@@ -2,18 +2,16 @@ package ai.h2o.mojos.deploy.common.transform;
 
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 
-/**
- * Thrown on issues with the {@link ScoreRequest}.
- */
+/** Thrown on issues with the {@link ScoreRequest}. */
 public class ScoreRequestFormatException extends Exception {
-    private final ScoreRequest exampleRequest;
+  private final ScoreRequest exampleRequest;
 
-    public ScoreRequestFormatException(String message, ScoreRequest exampleRequest) {
-        super(message);
-        this.exampleRequest = exampleRequest;
-    }
+  public ScoreRequestFormatException(String message, ScoreRequest exampleRequest) {
+    super(message);
+    this.exampleRequest = exampleRequest;
+  }
 
-    public ScoreRequest getExampleRequest() {
-        return exampleRequest;
-    }
+  public ScoreRequest getExampleRequest() {
+    return exampleRequest;
+  }
 }

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/CsvToMojoFrameConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/CsvToMojoFrameConverterTest.java
@@ -1,158 +1,161 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import ai.h2o.mojos.runtime.frame.MojoColumn.Type;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
-import org.junit.jupiter.api.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import static com.google.common.truth.Truth.assertThat;
-import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 class CsvToMojoFrameConverterTest {
-    private final CsvToMojoFrameConverter converter = new CsvToMojoFrameConverter();
+  private final CsvToMojoFrameConverter converter = new CsvToMojoFrameConverter();
 
-    @Test
-    void convertEmptyFile_fails() {
-        // Given
-        InputStream csv = toCsvStream("");
+  @Test
+  void convertEmptyFile_fails() {
+    // Given
+    InputStream csv = toCsvStream("");
 
-        // When & Then
-        assertThrows(IOException.class, () -> converter.apply(csv, emptyFrameBuilder()));
-    }
+    // When & Then
+    assertThrows(IOException.class, () -> converter.apply(csv, emptyFrameBuilder()));
+  }
 
-    @Test
-    void convertColumnCountsMismatch_fails() {
-        // Given
-        InputStream csv = toCsvStream("Field1,Field2,Field3");
+  @Test
+  void convertColumnCountsMismatch_fails() {
+    // Given
+    InputStream csv = toCsvStream("Field1,Field2,Field3");
 
-        // When & Then
-        assertThrows(IllegalArgumentException.class, () -> converter.apply(csv, emptyFrameBuilder()));
-    }
+    // When & Then
+    assertThrows(IllegalArgumentException.class, () -> converter.apply(csv, emptyFrameBuilder()));
+  }
 
-    @Test
-    void convertOnlyHeaders_succeeds() throws IOException {
-        // Given
-        String[] names = {"Field1", "Field2", "Field3"};
-        Type[] types = {Type.Str, Type.Str, Type.Str};
-        InputStream csv = toCsvStream("Field1,Field2,Field3");
+  @Test
+  void convertOnlyHeaders_succeeds() throws IOException {
+    // Given
+    String[] names = {"Field1", "Field2", "Field3"};
+    Type[] types = {Type.Str, Type.Str, Type.Str};
+    InputStream csv = toCsvStream("Field1,Field2,Field3");
 
-        // When
-        MojoFrame result = converter.apply(csv, frameBuilder(names, types));
+    // When
+    MojoFrame result = converter.apply(csv, frameBuilder(names, types));
 
-        // Then
-        assertThat(result.getNcols()).isEqualTo(3);
-        assertThat(result.getNrows()).isEqualTo(0);
-    }
+    // Then
+    assertThat(result.getNcols()).isEqualTo(3);
+    assertThat(result.getNrows()).isEqualTo(0);
+  }
 
-    @Test
-    void convertWithData_succeeds() throws IOException {
-        // Given
-        String[] names = {"Field1", "Field2"};
-        Type[] types = {Type.Str, Type.Int64};
-        InputStream csv = toCsvStream("Field1,Field2", "value1,1", "value2,2");
+  @Test
+  void convertWithData_succeeds() throws IOException {
+    // Given
+    String[] names = {"Field1", "Field2"};
+    Type[] types = {Type.Str, Type.Int64};
+    InputStream csv = toCsvStream("Field1,Field2", "value1,1", "value2,2");
 
-        // When
-        MojoFrame result = converter.apply(csv, frameBuilder(names, types));
+    // When
+    MojoFrame result = converter.apply(csv, frameBuilder(names, types));
 
-        // Then
-        assertThat(result.getColumnNames()).isEqualTo(names);
-        assertThat(result.getColumnTypes()).isEqualTo(types);
-        String[] expectedStrValues = {"value1", "value2"};
-        String[] expectedInt64Values = {"1", "2"};
-        assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(expectedStrValues);
-        assertThat(result.getColumn(1).getDataAsStrings()).isEqualTo(expectedInt64Values);
-    }
+    // Then
+    assertThat(result.getColumnNames()).isEqualTo(names);
+    assertThat(result.getColumnTypes()).isEqualTo(types);
+    String[] expectedStrValues = {"value1", "value2"};
+    String[] expectedInt64Values = {"1", "2"};
+    assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(expectedStrValues);
+    assertThat(result.getColumn(1).getDataAsStrings()).isEqualTo(expectedInt64Values);
+  }
 
-    @Test
-    void convertNAWithoutMissingValues_fails() {
-        // Given
-        String[] names = {"Field1"};
-        Type[] types = {Type.Int32};
-        InputStream csv = toCsvStream("Field1", "NA");
+  @Test
+  void convertNAWithoutMissingValues_fails() {
+    // Given
+    String[] names = {"Field1"};
+    Type[] types = {Type.Int32};
+    InputStream csv = toCsvStream("Field1", "NA");
 
-        // When & Then
-        NumberFormatException exception = assertThrows(NumberFormatException.class,
-                () -> converter.apply(csv, frameBuilder(names, types)));
-        assertThat(exception).hasMessageThat().contains("NA");
-    }
+    // When & Then
+    NumberFormatException exception =
+        assertThrows(
+            NumberFormatException.class, () -> converter.apply(csv, frameBuilder(names, types)));
+    assertThat(exception).hasMessageThat().contains("NA");
+  }
 
-    @Test
-    void convertNAWithMissingValues_succeeds() throws IOException {
-        // Given
-        String[] names = {"Field1"};
-        Type[] types = {Type.Int32};
-        InputStream csv = toCsvStream("Field1", "NA");
+  @Test
+  void convertNAWithMissingValues_succeeds() throws IOException {
+    // Given
+    String[] names = {"Field1"};
+    Type[] types = {Type.Int32};
+    InputStream csv = toCsvStream("Field1", "NA");
 
-        // When
-        MojoFrame result = converter.apply(csv, frameBuilderWithMissingValues(names, types, new String[]{"NA"}));
+    // When
+    MojoFrame result =
+        converter.apply(csv, frameBuilderWithMissingValues(names, types, new String[] {"NA"}));
 
-        // Then
-        assertThat(result.getColumnNames()).isEqualTo(names);
-        assertThat(result.getColumnTypes()).isEqualTo(types);
-        String[] expectedStrValues = {null};
-        assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(expectedStrValues);
-    }
+    // Then
+    assertThat(result.getColumnNames()).isEqualTo(names);
+    assertThat(result.getColumnTypes()).isEqualTo(types);
+    String[] expectedStrValues = {null};
+    assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(expectedStrValues);
+  }
 
-    @Test
-    void convertWithColumnReordering_succeeds() throws IOException {
-        // Given
-        String[] names = {"Field1", "Field2"};
-        Type[] types = {Type.Str, Type.Int64};
-        InputStream csv = toCsvStream("Field2,Field1", "1,value1", "2,value2");
+  @Test
+  void convertWithColumnReordering_succeeds() throws IOException {
+    // Given
+    String[] names = {"Field1", "Field2"};
+    Type[] types = {Type.Str, Type.Int64};
+    InputStream csv = toCsvStream("Field2,Field1", "1,value1", "2,value2");
 
-        // When
-        MojoFrame result = converter.apply(csv, frameBuilder(names, types));
+    // When
+    MojoFrame result = converter.apply(csv, frameBuilder(names, types));
 
-        // Then
-        assertThat(result.getColumnNames()).isEqualTo(names);
-        assertThat(result.getColumnTypes()).isEqualTo(types);
-        String[] expectedStrValues = {"value1", "value2"};
-        String[] expectedInt64Values = {"1", "2"};
-        assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(expectedStrValues);
-        assertThat(result.getColumn(1).getDataAsStrings()).isEqualTo(expectedInt64Values);
-    }
+    // Then
+    assertThat(result.getColumnNames()).isEqualTo(names);
+    assertThat(result.getColumnTypes()).isEqualTo(types);
+    String[] expectedStrValues = {"value1", "value2"};
+    String[] expectedInt64Values = {"1", "2"};
+    assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(expectedStrValues);
+    assertThat(result.getColumn(1).getDataAsStrings()).isEqualTo(expectedInt64Values);
+  }
 
-    @Test
-    void convertMoreTypes_succeeds() throws IOException {
-        // Given
-        Type[] types = {Type.Str, Type.Int32, Type.Int64, Type.Float32, Type.Float64, Type.Bool};
-        String[] names = Stream.of(types).map(Object::toString).toArray(String[]::new);
-        InputStream csv = toCsvStream(String.join(",", names), "test,1,2,1.5,2.5,false");
+  @Test
+  void convertMoreTypes_succeeds() throws IOException {
+    // Given
+    Type[] types = {Type.Str, Type.Int32, Type.Int64, Type.Float32, Type.Float64, Type.Bool};
+    String[] names = Stream.of(types).map(Object::toString).toArray(String[]::new);
+    InputStream csv = toCsvStream(String.join(",", names), "test,1,2,1.5,2.5,false");
 
-        // When
-        MojoFrame result = converter.apply(csv, frameBuilder(names, types));
+    // When
+    MojoFrame result = converter.apply(csv, frameBuilder(names, types));
 
-        // Then
-        assertThat(result.getColumnNames()).isEqualTo(names);
-        assertThat(result.getColumnTypes()).isEqualTo(types);
-        String[] expectedValues = {"test", "1", "2", "1.5", "2.5", "0"};
-        String[] actualValues = IntStream.range(0, types.length).mapToObj(
-                i -> result.getColumn(i).getDataAsStrings()[0]).toArray(String[]::new);
-        assertThat(actualValues).isEqualTo(expectedValues);
-    }
+    // Then
+    assertThat(result.getColumnNames()).isEqualTo(names);
+    assertThat(result.getColumnTypes()).isEqualTo(types);
+    String[] expectedValues = {"test", "1", "2", "1.5", "2.5", "0"};
+    String[] actualValues =
+        IntStream.range(0, types.length)
+            .mapToObj(i -> result.getColumn(i).getDataAsStrings()[0])
+            .toArray(String[]::new);
+    assertThat(actualValues).isEqualTo(expectedValues);
+  }
 
-    private static MojoFrameBuilder emptyFrameBuilder() {
-        return new MojoFrameBuilder(MojoFrameMeta.getEmpty());
-    }
+  private static MojoFrameBuilder emptyFrameBuilder() {
+    return new MojoFrameBuilder(MojoFrameMeta.getEmpty());
+  }
 
-    private static MojoFrameBuilder frameBuilder(String[] columns, Type[] types) {
-        return new MojoFrameBuilder(new MojoFrameMeta(columns, types));
-    }
+  private static MojoFrameBuilder frameBuilder(String[] columns, Type[] types) {
+    return new MojoFrameBuilder(new MojoFrameMeta(columns, types));
+  }
 
-    private static MojoFrameBuilder frameBuilderWithMissingValues(String[] columns, Type[] types,
-                                                                  String[] missingValues) {
-        return new MojoFrameBuilder(new MojoFrameMeta(columns, types), asList(missingValues));
-    }
+  private static MojoFrameBuilder frameBuilderWithMissingValues(
+      String[] columns, Type[] types, String[] missingValues) {
+    return new MojoFrameBuilder(new MojoFrameMeta(columns, types), asList(missingValues));
+  }
 
-    static private InputStream toCsvStream(String... rows) {
-        return new ByteArrayInputStream(String.join("\n", rows).getBytes());
-    }
+  private static InputStream toCsvStream(String... rows) {
+    return new ByteArrayInputStream(String.join("\n", rows).getBytes());
+  }
 }

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
@@ -1,5 +1,6 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.util.Arrays.asList;
 
 import ai.h2o.mojos.deploy.common.rest.model.Row;

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
@@ -1,5 +1,7 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static java.util.Arrays.asList;
+
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
@@ -8,130 +10,130 @@ import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
 import ai.h2o.mojos.runtime.frame.MojoRowBuilder;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-import java.util.stream.Stream;
-
-import static com.google.common.truth.Truth.assertThat;
-import static java.util.Arrays.asList;
-
 class MojoFrameToResponseConverterTest {
-    private final MojoFrameToResponseConverter converter = new MojoFrameToResponseConverter();
+  private final MojoFrameToResponseConverter converter = new MojoFrameToResponseConverter();
 
-    @Test
-    void convertEmptyRowsResponse_succeeds() {
-        // Given
-        ScoreRequest scoreRequest = new ScoreRequest();
-        MojoFrame mojoFrame = new MojoFrameBuilder(MojoFrameMeta.getEmpty()).toMojoFrame();
+  @Test
+  void convertEmptyRowsResponse_succeeds() {
+    // Given
+    ScoreRequest scoreRequest = new ScoreRequest();
+    MojoFrame mojoFrame = new MojoFrameBuilder(MojoFrameMeta.getEmpty()).toMojoFrame();
 
-        // When
-        ScoreResponse result = converter.apply(mojoFrame, scoreRequest);
+    // When
+    ScoreResponse result = converter.apply(mojoFrame, scoreRequest);
 
-        // Then
-        assertThat(result.getScore()).isEmpty();
+    // Then
+    assertThat(result.getScore()).isEmpty();
+  }
+
+  @Test
+  void convertSingleFieldResponse_succeeds() {
+    // Given
+    String[] fields = {"field"};
+    Type[] types = {Type.Str};
+    String[][] values = {{"value"}};
+    ScoreRequest scoreRequest = new ScoreRequest();
+
+    // When
+    ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
+
+    // Then
+    assertThat(result.getScore()).containsExactly(asRow("value"));
+  }
+
+  @Test
+  void convertIncludesOneField_succeeds() {
+    // Given
+    String[] fields = {"outputField"};
+    Type[] types = {Type.Str};
+    String[][] values = {{"outputValue"}};
+    ScoreRequest scoreRequest = new ScoreRequest();
+    scoreRequest.addFieldsItem("inputField");
+    scoreRequest.addIncludeFieldsInOutputItem("inputField");
+    scoreRequest.addRowsItem(asRow("inputValue"));
+
+    // When
+    ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
+
+    // Then
+    assertThat(result.getScore()).containsExactly(asRow("inputValue", "outputValue"));
+  }
+
+  @Test
+  void convertIncludesSomeFields_succeeds() {
+    // Given
+    String[] fields = {"outputField1", "outputField2"};
+    Type[] types = {Type.Str, Type.Str};
+    String[][] values = {{"outputValue1", "outputValue2"}};
+    ScoreRequest scoreRequest = new ScoreRequest();
+    scoreRequest.setFields(asList("inputField1", "inputField2", "inputField3"));
+    scoreRequest.setIncludeFieldsInOutput(asList("inputField1", "inputField3"));
+    scoreRequest.addRowsItem(asRow("inputValue1", "omittedValue", "inputValue3"));
+
+    // When
+    ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
+
+    // Then
+    assertThat(result.getScore())
+        .containsExactly(asRow("inputValue1", "inputValue3", "outputValue1", "outputValue2"));
+  }
+
+  @Test
+  void convertMoreRowsResponse_succeeds() {
+    // Given
+    String[] fields = {"field"};
+    Type[] types = {Type.Str};
+    String[][] values = {{"value1"}, {"value2"}, {"value3"}};
+    ScoreRequest scoreRequest = new ScoreRequest();
+
+    // When
+    ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
+
+    // Then
+    assertThat(result.getScore())
+        .containsExactly(Stream.of(values).map(MojoFrameToResponseConverterTest::asRow).toArray());
+  }
+
+  @Test
+  void convertMoreTypesResponse_succeeds() {
+    // Given
+    Type[] types = {Type.Str, Type.Float32, Type.Float64, Type.Bool, Type.Int32, Type.Int64};
+    String[][] values = {{"str", "1.1", "2.2", "1", "123", "123456789"}};
+    ScoreRequest scoreRequest = new ScoreRequest();
+
+    // When
+    ScoreResponse result =
+        converter.apply(
+            buildMojoFrame(
+                Stream.of(types).map(Object::toString).toArray(String[]::new), types, values),
+            scoreRequest);
+
+    // Then
+    assertThat(result.getScore())
+        .containsExactly(Stream.of(values).map(MojoFrameToResponseConverterTest::asRow).toArray());
+  }
+
+  private static MojoFrame buildMojoFrame(String[] fields, Type[] types, String[][] values) {
+    MojoFrameMeta meta = new MojoFrameMeta(fields, types);
+    MojoFrameBuilder frameBuilder = new MojoFrameBuilder(meta);
+    for (String[] row : values) {
+      MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
+      int col = 0;
+      for (String value : row) {
+        rowBuilder.setValue(col++, value);
+      }
+      frameBuilder.addRow(rowBuilder);
     }
+    return frameBuilder.toMojoFrame();
+  }
 
-    @Test
-    void convertSingleFieldResponse_succeeds() {
-        // Given
-        String[] fields = {"field"};
-        Type[] types = {Type.Str};
-        String[][] values = {{"value"}};
-        ScoreRequest scoreRequest = new ScoreRequest();
-
-        // When
-        ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
-
-        // Then
-        assertThat(result.getScore()).containsExactly(asRow("value"));
-    }
-
-    @Test
-    void convertIncludesOneField_succeeds() {
-        // Given
-        String[] fields = {"outputField"};
-        Type[] types = {Type.Str};
-        String[][] values = {{"outputValue"}};
-        ScoreRequest scoreRequest = new ScoreRequest();
-        scoreRequest.addFieldsItem("inputField");
-        scoreRequest.addIncludeFieldsInOutputItem("inputField");
-        scoreRequest.addRowsItem(asRow("inputValue"));
-
-        // When
-        ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
-
-        // Then
-        assertThat(result.getScore()).containsExactly(asRow("inputValue", "outputValue"));
-    }
-
-    @Test
-    void convertIncludesSomeFields_succeeds() {
-        // Given
-        String[] fields = {"outputField1", "outputField2"};
-        Type[] types = {Type.Str, Type.Str};
-        String[][] values = {{"outputValue1", "outputValue2"}};
-        ScoreRequest scoreRequest = new ScoreRequest();
-        scoreRequest.setFields(asList("inputField1", "inputField2", "inputField3"));
-        scoreRequest.setIncludeFieldsInOutput(asList("inputField1", "inputField3"));
-        scoreRequest.addRowsItem(asRow("inputValue1", "omittedValue", "inputValue3"));
-
-        // When
-        ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
-
-        // Then
-        assertThat(result.getScore()).containsExactly(
-                asRow("inputValue1", "inputValue3", "outputValue1", "outputValue2"));
-    }
-
-    @Test
-    void convertMoreRowsResponse_succeeds() {
-        // Given
-        String[] fields = {"field"};
-        Type[] types = {Type.Str};
-        String[][] values = {{"value1"}, {"value2"}, {"value3"}};
-        ScoreRequest scoreRequest = new ScoreRequest();
-
-        // When
-        ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
-
-        // Then
-        assertThat(result.getScore()).containsExactly(Stream.of(values).map(MojoFrameToResponseConverterTest::asRow).toArray());
-    }
-
-    @Test
-    void convertMoreTypesResponse_succeeds() {
-        // Given
-        Type[] types = {Type.Str, Type.Float32, Type.Float64, Type.Bool, Type.Int32, Type.Int64};
-        String[][] values = {{"str", "1.1", "2.2", "1", "123", "123456789"}};
-        ScoreRequest scoreRequest = new ScoreRequest();
-
-        // When
-        ScoreResponse result = converter.apply(
-                buildMojoFrame(Stream.of(types).map(Object::toString).toArray(String[]::new), types, values),
-                scoreRequest);
-
-        // Then
-        assertThat(result.getScore()).containsExactly(Stream.of(values).map(MojoFrameToResponseConverterTest::asRow).toArray());
-    }
-
-    static private MojoFrame buildMojoFrame(String[] fields, Type[] types, String[][] values) {
-        MojoFrameMeta meta = new MojoFrameMeta(fields, types);
-        MojoFrameBuilder frameBuilder = new MojoFrameBuilder(meta);
-        for (String[] row : values) {
-            MojoRowBuilder rowBuilder = frameBuilder.getMojoRowBuilder();
-            int col = 0;
-            for (String value : row) {
-                rowBuilder.setValue(col++, value);
-            }
-            frameBuilder.addRow(rowBuilder);
-        }
-        return frameBuilder.toMojoFrame();
-    }
-
-    private static Row asRow(String... values) {
-        Row row = new Row();
-        row.ensureCapacity(values.length);
-        row.addAll(asList(values));
-        return row;
-    }
+  private static Row asRow(String... values) {
+    Row row = new Row();
+    row.ensureCapacity(values.length);
+    row.addAll(asList(values));
+    return row;
+  }
 }

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverterTest.java
@@ -9,167 +9,164 @@ import ai.h2o.mojos.runtime.frame.MojoColumn.Type;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-import java.util.stream.Stream;
-
-import static com.google.common.truth.Truth.assertThat;
-
 class MojoPipelineToModelInfoConverterTest {
-    static private String TEST_UUID = "TEST_UUID";
-    private final MojoPipelineToModelInfoConverter converter = new MojoPipelineToModelInfoConverter();
+  private static String TEST_UUID = "TEST_UUID";
+  private final MojoPipelineToModelInfoConverter converter = new MojoPipelineToModelInfoConverter();
 
-    @Test
-    void convertNoFields_succeeds() {
-        // Given
-        MojoPipeline pipeline = new DummyPipeline(TEST_UUID, MojoFrameMeta.getEmpty(), MojoFrameMeta.getEmpty());
+  @Test
+  void convertNoFields_succeeds() {
+    // Given
+    MojoPipeline pipeline =
+        new DummyPipeline(TEST_UUID, MojoFrameMeta.getEmpty(), MojoFrameMeta.getEmpty());
 
-        // When
-        Model result = converter.apply(pipeline);
+    // When
+    Model result = converter.apply(pipeline);
 
-        // Then
-        assertThat(result.getId()).isEqualTo(TEST_UUID);
-        assertThat(result.getSchema().getInputFields()).isEmpty();
-        assertThat(result.getSchema().getOutputFields()).isEmpty();
+    // Then
+    assertThat(result.getId()).isEqualTo(TEST_UUID);
+    assertThat(result.getSchema().getInputFields()).isEmpty();
+    assertThat(result.getSchema().getOutputFields()).isEmpty();
+  }
+
+  @Test
+  void convertSingleInputField_succeeds() {
+    // Given
+    String[] inputNames = {"field1"};
+    Type[] inputTypes = {Type.Str};
+    MojoPipeline pipeline =
+        DummyPipeline.ofMeta(new MojoFrameMeta(inputNames, inputTypes), MojoFrameMeta.getEmpty());
+
+    // When
+    Model result = converter.apply(pipeline);
+
+    // Then
+    DataTypeEnum[] expectedInputTypes = {DataTypeEnum.STR};
+    assertThat(result.getSchema().getInputFields())
+        .containsExactlyElementsIn(toDataFields(inputNames, expectedInputTypes))
+        .inOrder();
+    assertThat(result.getSchema().getOutputFields()).isEmpty();
+  }
+
+  @Test
+  void convertSingleOutputField_succeeds() {
+    // Given
+    String[] outputNames = {"field1"};
+    Type[] outputTypes = {Type.Str};
+    MojoPipeline pipeline =
+        DummyPipeline.ofMeta(MojoFrameMeta.getEmpty(), new MojoFrameMeta(outputNames, outputTypes));
+
+    // When
+    Model result = converter.apply(pipeline);
+
+    // Then
+    DataTypeEnum[] expectedOutputTypes = {DataTypeEnum.STR};
+    assertThat(result.getSchema().getInputFields()).isEmpty();
+    assertThat(result.getSchema().getOutputFields())
+        .containsExactlyElementsIn(toDataFields(outputNames, expectedOutputTypes))
+        .inOrder();
+  }
+
+  @Test
+  void convertMoreFields_succeeds() {
+    // Given
+    String[] inputNames = {"field1", "field2"};
+    Type[] inputTypes = {Type.Str, Type.Str};
+    String[] outputNames = {"field3", "field4"};
+    Type[] outputTypes = {Type.Int64, Type.Int64};
+    MojoPipeline pipeline =
+        DummyPipeline.ofMeta(
+            new MojoFrameMeta(inputNames, inputTypes), new MojoFrameMeta(outputNames, outputTypes));
+
+    // When
+    Model result = converter.apply(pipeline);
+
+    // Then
+    DataTypeEnum[] expectedInputTypes = {DataTypeEnum.STR, DataTypeEnum.STR};
+    DataTypeEnum[] expectedOutputTypes = {DataTypeEnum.INT64, DataTypeEnum.INT64};
+    assertThat(result.getSchema().getInputFields())
+        .containsExactlyElementsIn(toDataFields(inputNames, expectedInputTypes))
+        .inOrder();
+    assertThat(result.getSchema().getOutputFields())
+        .containsExactlyElementsIn(toDataFields(outputNames, expectedOutputTypes))
+        .inOrder();
+  }
+
+  @Test
+  void convertAllTypes_succeeds() {
+    // Given
+    Type[] outputTypes = Type.values();
+    String[] outputNames = Stream.of(Type.values()).map(Type::toString).toArray(String[]::new);
+    MojoPipeline pipeline =
+        DummyPipeline.ofMeta(MojoFrameMeta.getEmpty(), new MojoFrameMeta(outputNames, outputTypes));
+
+    // When
+    Model result = converter.apply(pipeline);
+
+    // Then
+    DataTypeEnum[] expectedOutputTypes = DataTypeEnum.values();
+    assertThat(result.getSchema().getInputFields()).isEmpty();
+    // No ordering as it differ between the two enums.
+    assertThat(result.getSchema().getOutputFields())
+        .containsExactlyElementsIn(toDataFields(outputNames, expectedOutputTypes));
+  }
+
+  private static DataField[] toDataFields(String[] inputNames, DataTypeEnum[] inputTypes) {
+    DataField[] result = new DataField[inputNames.length];
+    for (int i = 0; i < inputNames.length; i++) {
+      DataField dataField = new DataField();
+      dataField.name(inputNames[i]);
+      dataField.dataType(inputTypes[i]);
+      result[i] = dataField;
+    }
+    return result;
+  }
+
+  /** Dummy test {@link MojoPipeline} just to be able to test the transformation. */
+  private static class DummyPipeline extends MojoPipeline {
+    private final MojoFrameMeta inputMeta;
+    private final MojoFrameMeta outputMeta;
+
+    private DummyPipeline(String uuid, MojoFrameMeta inputMeta, MojoFrameMeta outputMeta) {
+      super(uuid, null, null);
+      this.inputMeta = inputMeta;
+      this.outputMeta = outputMeta;
     }
 
-    @Test
-    void convertSingleInputField_succeeds() {
-        // Given
-        String[] inputNames = {"field1"};
-        Type[] inputTypes = {Type.Str};
-        MojoPipeline pipeline = DummyPipeline.ofMeta(
-                new MojoFrameMeta(inputNames, inputTypes),
-                MojoFrameMeta.getEmpty());
-
-        // When
-        Model result = converter.apply(pipeline);
-
-        // Then
-        DataTypeEnum[] expectedInputTypes = {DataTypeEnum.STR};
-        assertThat(result.getSchema().getInputFields()).containsExactlyElementsIn(
-                toDataFields(inputNames, expectedInputTypes)).inOrder();
-        assertThat(result.getSchema().getOutputFields()).isEmpty();
+    static DummyPipeline ofMeta(MojoFrameMeta inputMeta, MojoFrameMeta outputMeta) {
+      return new DummyPipeline(TEST_UUID, inputMeta, outputMeta);
     }
 
-    @Test
-    void convertSingleOutputField_succeeds() {
-        // Given
-        String[] outputNames = {"field1"};
-        Type[] outputTypes = {Type.Str};
-        MojoPipeline pipeline = DummyPipeline.ofMeta(
-                MojoFrameMeta.getEmpty(),
-                new MojoFrameMeta(outputNames, outputTypes));
-
-        // When
-        Model result = converter.apply(pipeline);
-
-        // Then
-        DataTypeEnum[] expectedOutputTypes = {DataTypeEnum.STR};
-        assertThat(result.getSchema().getInputFields()).isEmpty();
-        assertThat(result.getSchema().getOutputFields()).containsExactlyElementsIn(
-                toDataFields(outputNames, expectedOutputTypes)).inOrder();
+    @Override
+    public MojoFrameMeta getInputMeta() {
+      return inputMeta;
     }
 
-    @Test
-    void convertMoreFields_succeeds() {
-        // Given
-        String[] inputNames = {"field1", "field2"};
-        Type[] inputTypes = {Type.Str, Type.Str};
-        String[] outputNames = {"field3", "field4"};
-        Type[] outputTypes = {Type.Int64, Type.Int64};
-        MojoPipeline pipeline = DummyPipeline.ofMeta(
-                new MojoFrameMeta(inputNames, inputTypes),
-                new MojoFrameMeta(outputNames, outputTypes));
-
-        // When
-        Model result = converter.apply(pipeline);
-
-        // Then
-        DataTypeEnum[] expectedInputTypes = {DataTypeEnum.STR, DataTypeEnum.STR};
-        DataTypeEnum[] expectedOutputTypes = {DataTypeEnum.INT64, DataTypeEnum.INT64};
-        assertThat(result.getSchema().getInputFields()).containsExactlyElementsIn(
-                toDataFields(inputNames, expectedInputTypes)).inOrder();
-        assertThat(result.getSchema().getOutputFields()).containsExactlyElementsIn(
-                toDataFields(outputNames, expectedOutputTypes)).inOrder();
+    @Override
+    public MojoFrameMeta getOutputMeta() {
+      return outputMeta;
     }
 
-    @Test
-    void convertAllTypes_succeeds() {
-        // Given
-        Type[] outputTypes = Type.values();
-        String[] outputNames = Stream.of(Type.values()).map(Type::toString).toArray(String[]::new);
-        MojoPipeline pipeline = DummyPipeline.ofMeta(
-                MojoFrameMeta.getEmpty(),
-                new MojoFrameMeta(outputNames, outputTypes));
-
-        // When
-        Model result = converter.apply(pipeline);
-
-        // Then
-        DataTypeEnum[] expectedOutputTypes = DataTypeEnum.values();
-        assertThat(result.getSchema().getInputFields()).isEmpty();
-        // No ordering as it differ between the two enums.
-        assertThat(result.getSchema().getOutputFields()).containsExactlyElementsIn(
-                toDataFields(outputNames, expectedOutputTypes));
+    @Override
+    protected MojoFrameBuilder getFrameBuilder(MojoColumn.Kind kind) {
+      throw new AssertionError("Not supported by test DummyPipeline.");
     }
 
-    static private DataField[] toDataFields(String[] inputNames, DataTypeEnum[] inputTypes) {
-        DataField[] result = new DataField[inputNames.length];
-        for (int i = 0; i < inputNames.length; i++) {
-            DataField dataField = new DataField();
-            dataField.name(inputNames[i]);
-            dataField.dataType(inputTypes[i]);
-            result[i] = dataField;
-        }
-        return result;
+    @Override
+    protected MojoFrameMeta getMeta(MojoColumn.Kind kind) {
+      throw new AssertionError("Not supported by test DummyPipeline.");
     }
 
-    /**
-     * Dummy test {@link MojoPipeline} just to be able to test the transformation.
-     */
-    private static class DummyPipeline extends MojoPipeline {
-        private final MojoFrameMeta inputMeta;
-        private final MojoFrameMeta outputMeta;
-
-        private DummyPipeline(String uuid, MojoFrameMeta inputMeta, MojoFrameMeta outputMeta) {
-            super(uuid, null, null);
-            this.inputMeta = inputMeta;
-            this.outputMeta = outputMeta;
-        }
-
-        static DummyPipeline ofMeta(MojoFrameMeta inputMeta, MojoFrameMeta outputMeta) {
-            return new DummyPipeline(TEST_UUID, inputMeta, outputMeta);
-        }
-
-        @Override
-        public MojoFrameMeta getInputMeta() {
-            return inputMeta;
-        }
-
-        @Override
-        public MojoFrameMeta getOutputMeta() {
-            return outputMeta;
-        }
-
-        @Override
-        protected MojoFrameBuilder getFrameBuilder(MojoColumn.Kind kind) {
-            throw new AssertionError("Not supported by test DummyPipeline.");
-        }
-
-        @Override
-        protected MojoFrameMeta getMeta(MojoColumn.Kind kind) {
-            throw new AssertionError("Not supported by test DummyPipeline.");
-        }
-
-        @Override
-        public MojoFrame transform(MojoFrame inputFrame) {
-            throw new AssertionError("Not supported by test DummyPipeline.");
-        }
-
-        @Override
-        public MojoFrame transform(MojoFrame inputFrame, MojoFrame outputFrame) {
-            throw new AssertionError("Not supported by test DummyPipeline.");
-        }
+    @Override
+    public MojoFrame transform(MojoFrame inputFrame) {
+      throw new AssertionError("Not supported by test DummyPipeline.");
     }
+
+    @Override
+    public MojoFrame transform(MojoFrame inputFrame, MojoFrame outputFrame) {
+      throw new AssertionError("Not supported by test DummyPipeline.");
+    }
+  }
 }

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverterTest.java
@@ -1,5 +1,7 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import ai.h2o.mojos.deploy.common.rest.model.DataField;
 import ai.h2o.mojos.deploy.common.rest.model.DataField.DataTypeEnum;
 import ai.h2o.mojos.deploy.common.rest.model.Model;

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestCheckerTest.java
@@ -1,183 +1,183 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoColumn;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 @ExtendWith(MockitoExtension.class)
 class RequestCheckerTest {
-    private final ScoreRequest exampleRequest = new ScoreRequest();
-    @Mock
-    private SampleRequestBuilder sampleRequestBuilder;
-    @InjectMocks
-    private RequestChecker checker;
+  private final ScoreRequest exampleRequest = new ScoreRequest();
+  @Mock private SampleRequestBuilder sampleRequestBuilder;
+  @InjectMocks private RequestChecker checker;
 
-    @Test
-    void verifyValidRequest_succeeds() throws ScoreRequestFormatException {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addRowsItem(toRow("text"));
-        MojoFrameMeta expectedMeta = new MojoFrameMeta(
-                new String[]{"field1"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str});
+  @Test
+  void verifyValidRequest_succeeds() throws ScoreRequestFormatException {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addRowsItem(toRow("text"));
+    MojoFrameMeta expectedMeta =
+        new MojoFrameMeta(new String[] {"field1"}, new MojoColumn.Type[] {MojoColumn.Type.Str});
 
-        // When
-        checker.verify(request, expectedMeta);
+    // When
+    checker.verify(request, expectedMeta);
 
-        // Then all ok
-    }
+    // Then all ok
+  }
 
-    @Test
-    void verifyNullRequest_throws() {
-        // Given
-        ScoreRequest request = null;
-        MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
-        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
+  @Test
+  void verifyNullRequest_throws() {
+    // Given
+    ScoreRequest request = null;
+    MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
+    given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
-        // When & then
-        ScoreRequestFormatException exception =
-                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("empty");
-        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
-    }
+    // When & then
+    ScoreRequestFormatException exception =
+        assertThrows(
+            ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+    assertThat(exception.getMessage()).contains("empty");
+    assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
+  }
 
-    @Test
-    void verifyEmptyRequest_throws() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
-        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
+  @Test
+  void verifyEmptyRequest_throws() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    MojoFrameMeta expectedMeta = MojoFrameMeta.getEmpty();
+    given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
-        // When & then
-        ScoreRequestFormatException exception =
-                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("empty");
-        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
-    }
+    // When & then
+    ScoreRequestFormatException exception =
+        assertThrows(
+            ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+    assertThat(exception.getMessage()).contains("empty");
+    assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
+  }
 
-    @Test
-    void verifyEmptyFieldsRequest_throws() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addRowsItem(toRow("text"));
-        MojoFrameMeta expectedMeta = new MojoFrameMeta(
-                new String[]{"field1"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str});
-        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
+  @Test
+  void verifyEmptyFieldsRequest_throws() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addRowsItem(toRow("text"));
+    MojoFrameMeta expectedMeta =
+        new MojoFrameMeta(new String[] {"field1"}, new MojoColumn.Type[] {MojoColumn.Type.Str});
+    given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
-        // When & then
-        ScoreRequestFormatException exception =
-                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("fields cannot be empty");
-        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
-    }
+    // When & then
+    ScoreRequestFormatException exception =
+        assertThrows(
+            ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+    assertThat(exception.getMessage()).contains("fields cannot be empty");
+    assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
+  }
 
-    @Test
-    void verifyEmptyRowsRequest_throws() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        MojoFrameMeta expectedMeta = new MojoFrameMeta(
-                new String[]{"field1"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str});
-        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
+  @Test
+  void verifyEmptyRowsRequest_throws() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    MojoFrameMeta expectedMeta =
+        new MojoFrameMeta(new String[] {"field1"}, new MojoColumn.Type[] {MojoColumn.Type.Str});
+    given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
-        // When & then
-        ScoreRequestFormatException exception =
-                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("rows cannot be empty");
-        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
-    }
+    // When & then
+    ScoreRequestFormatException exception =
+        assertThrows(
+            ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+    assertThat(exception.getMessage()).contains("rows cannot be empty");
+    assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
+  }
 
-    @Test
-    void verifyMismatchedFieldsRequest_throws() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("a_fields");
-        request.addRowsItem(toRow("text"));
-        MojoFrameMeta expectedMeta = new MojoFrameMeta(
-                new String[]{"different_fields"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str});
-        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
+  @Test
+  void verifyMismatchedFieldsRequest_throws() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("a_fields");
+    request.addRowsItem(toRow("text"));
+    MojoFrameMeta expectedMeta =
+        new MojoFrameMeta(
+            new String[] {"different_fields"}, new MojoColumn.Type[] {MojoColumn.Type.Str});
+    given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
-        // When & then
-        ScoreRequestFormatException exception =
-                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("fields don't contain all");
-        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
-    }
+    // When & then
+    ScoreRequestFormatException exception =
+        assertThrows(
+            ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+    assertThat(exception.getMessage()).contains("fields don't contain all");
+    assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
+  }
 
-    @Test
-    void verifyTooFewFieldsRequest_throws() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addRowsItem(toRow("text"));
-        MojoFrameMeta expectedMeta = new MojoFrameMeta(
-                new String[]{"field1", "field2"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str, MojoColumn.Type.Str});
-        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
+  @Test
+  void verifyTooFewFieldsRequest_throws() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addRowsItem(toRow("text"));
+    MojoFrameMeta expectedMeta =
+        new MojoFrameMeta(
+            new String[] {"field1", "field2"},
+            new MojoColumn.Type[] {MojoColumn.Type.Str, MojoColumn.Type.Str});
+    given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
-        // When & then
-        ScoreRequestFormatException exception =
-                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("fields don't contain all");
-        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
-    }
+    // When & then
+    ScoreRequestFormatException exception =
+        assertThrows(
+            ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+    assertThat(exception.getMessage()).contains("fields don't contain all");
+    assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
+  }
 
-    @Test
-    void verifyExtraFieldsRequest_succeeds() throws ScoreRequestFormatException {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addFieldsItem("field2");
-        request.addRowsItem(toRow("text1", "text2"));
-        MojoFrameMeta expectedMeta = new MojoFrameMeta(
-                new String[]{"field1"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str});
+  @Test
+  void verifyExtraFieldsRequest_succeeds() throws ScoreRequestFormatException {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addFieldsItem("field2");
+    request.addRowsItem(toRow("text1", "text2"));
+    MojoFrameMeta expectedMeta =
+        new MojoFrameMeta(new String[] {"field1"}, new MojoColumn.Type[] {MojoColumn.Type.Str});
 
-        // When
-        checker.verify(request, expectedMeta);
+    // When
+    checker.verify(request, expectedMeta);
 
-        // Then all ok
-    }
+    // Then all ok
+  }
 
-    @Test
-    void verifyMismatchedRowsRequest_throws() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addRowsItem(toRow("text"));
-        request.addRowsItem(toRow("text", "additional text"));
-        MojoFrameMeta expectedMeta = new MojoFrameMeta(
-                new String[]{"field1"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str});
-        given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
+  @Test
+  void verifyMismatchedRowsRequest_throws() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addRowsItem(toRow("text"));
+    request.addRowsItem(toRow("text", "additional text"));
+    MojoFrameMeta expectedMeta =
+        new MojoFrameMeta(new String[] {"field1"}, new MojoColumn.Type[] {MojoColumn.Type.Str});
+    given(sampleRequestBuilder.build(any())).willReturn(exampleRequest);
 
-        // When & then
-        ScoreRequestFormatException exception =
-                assertThrows(ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
-        assertThat(exception.getMessage()).contains("row 1");
-        assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
-    }
+    // When & then
+    ScoreRequestFormatException exception =
+        assertThrows(
+            ScoreRequestFormatException.class, () -> checker.verify(request, expectedMeta));
+    assertThat(exception.getMessage()).contains("row 1");
+    assertThat(exception.getExampleRequest()).isSameAs(exampleRequest);
+  }
 
-    private static Row toRow(String... values) {
-        Row row = new Row();
-        row.addAll(Arrays.asList(values));
-        return row;
-    }
+  private static Row toRow(String... values) {
+    Row row = new Row();
+    row.addAll(Arrays.asList(values));
+    return row;
+  }
 }

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestToMojoFrameConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/RequestToMojoFrameConverterTest.java
@@ -1,178 +1,173 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoColumn.Type;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import ai.h2o.mojos.runtime.frame.MojoFrameBuilder;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.stream.Stream;
-
-import static com.google.common.truth.Truth.assertThat;
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 class RequestToMojoFrameConverterTest {
-    private static final String[] SINGLE_NULL = {null};
-    private final RequestToMojoFrameConverter converter = new RequestToMojoFrameConverter();
+  private static final String[] SINGLE_NULL = {null};
+  private final RequestToMojoFrameConverter converter = new RequestToMojoFrameConverter();
 
-    @Test
-    void convertEmptyRowsRequest_succeeds() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
+  @Test
+  void convertEmptyRowsRequest_succeeds() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
 
-        // When
-        MojoFrame result = converter.apply(request, emptyFrameBuilder());
+    // When
+    MojoFrame result = converter.apply(request, emptyFrameBuilder());
 
-        // Then
-        assertThat(result.getNcols()).isEqualTo(0);
-        assertThat(result.getNrows()).isEqualTo(0);
+    // Then
+    assertThat(result.getNcols()).isEqualTo(0);
+    assertThat(result.getNrows()).isEqualTo(0);
+  }
+
+  @Test
+  void convertSingleFieldRequest_succeeds() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addRowsItem(asRow("value"));
+
+    // When
+    MojoFrame result =
+        converter.apply(request, frameBuilder(new String[] {"field1"}, new Type[] {Type.Str}));
+
+    // Then
+    assertThat(result.getNcols()).isEqualTo(1);
+    assertThat(result.getNrows()).isEqualTo(1);
+    assertThat(result.getColumnNames()).asList().containsExactly("field1");
+    assertThat(result.getColumn(0).getDataAsStrings()).asList().containsExactly("value");
+  }
+
+  @Test
+  void convertNAFieldRequestWithoutMissingValues_fails() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addRowsItem(asRow("NA"));
+
+    // When & Then
+    NumberFormatException exception =
+        assertThrows(
+            NumberFormatException.class,
+            () ->
+                converter.apply(
+                    request, frameBuilder(new String[] {"field1"}, new Type[] {Type.Int32})));
+    assertThat(exception).hasMessageThat().contains("NA");
+  }
+
+  @Test
+  void convertNAFieldRequestWithMissingValues_succeeds() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addRowsItem(asRow("NA"));
+
+    // When
+    MojoFrame result =
+        converter.apply(
+            request,
+            frameBuilderWithMissingValues(
+                new String[] {"field1"}, new Type[] {Type.Int32}, new String[] {"NA"}));
+
+    // Then
+    assertThat(result.getNcols()).isEqualTo(1);
+    assertThat(result.getNrows()).isEqualTo(1);
+    assertThat(result.getColumnNames()).asList().containsExactly("field1");
+    assertThat(result.getColumn(0).getDataAsStrings())
+        .asList()
+        .containsExactlyElementsIn(SINGLE_NULL);
+  }
+
+  @Test
+  void convertNullFieldRequestWithMissingValues_succeeds() {
+    // Given
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.addRowsItem(asRow(SINGLE_NULL));
+
+    // When
+    MojoFrame result =
+        converter.apply(request, frameBuilder(new String[] {"field1"}, new Type[] {Type.Int32}));
+
+    // Then
+    assertThat(result.getNcols()).isEqualTo(1);
+    assertThat(result.getNrows()).isEqualTo(1);
+    assertThat(result.getColumnNames()).asList().containsExactly("field1");
+    assertThat(result.getColumn(0).getDataAsStrings())
+        .asList()
+        .containsExactlyElementsIn(SINGLE_NULL);
+  }
+
+  @Test
+  void convertMoreRowsRequest_succeeds() {
+    // Given
+    String[] values = {"value1", "value2", "value3"};
+    ScoreRequest request = new ScoreRequest();
+    request.addFieldsItem("field1");
+    request.rows(Stream.of(values).map(RequestToMojoFrameConverterTest::asRow).collect(toList()));
+
+    // When
+    MojoFrame result =
+        converter.apply(request, frameBuilder(new String[] {"field1"}, new Type[] {Type.Str}));
+
+    // Then
+    assertThat(result.getNcols()).isEqualTo(1);
+    assertThat(result.getNrows()).isEqualTo(3);
+    assertThat(result.getColumnNames()).asList().containsExactly("field1");
+    assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(values);
+  }
+
+  @Test
+  void convertMoreTypesRequest_succeeds() {
+    // Given
+    Type[] types = {Type.Str, Type.Float32, Type.Float64, Type.Bool, Type.Int32, Type.Int64};
+    List<String> fields = Stream.of(types).map(Object::toString).collect(toList());
+    String[] values = {"str", "1.1", "2.2", "1", "123", "123456789"};
+    ScoreRequest request = new ScoreRequest();
+    request.setFields(fields);
+    request.addRowsItem(asRow(values));
+
+    // When
+    MojoFrame result = converter.apply(request, frameBuilder(fields.toArray(new String[0]), types));
+
+    // Then
+    assertThat(result.getNcols()).isEqualTo(types.length);
+    assertThat(result.getNrows()).isEqualTo(1);
+    assertThat(result.getColumnNames()).asList().containsExactlyElementsIn(fields);
+    for (int col = 0; col < types.length; col++) {
+      assertThat(result.getColumn(col).getDataAsStrings()[0]).isEqualTo(values[col]);
     }
+  }
 
-    @Test
-    void convertSingleFieldRequest_succeeds() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addRowsItem(asRow("value"));
+  private static MojoFrameBuilder emptyFrameBuilder() {
+    return new MojoFrameBuilder(MojoFrameMeta.getEmpty());
+  }
 
-        // When
-        MojoFrame result = converter.apply(request,
-                frameBuilder(
-                        new String[]{"field1"},
-                        new Type[]{Type.Str}));
+  private static MojoFrameBuilder frameBuilder(String[] columns, Type[] types) {
+    return new MojoFrameBuilder(new MojoFrameMeta(columns, types));
+  }
 
-        // Then
-        assertThat(result.getNcols()).isEqualTo(1);
-        assertThat(result.getNrows()).isEqualTo(1);
-        assertThat(result.getColumnNames()).asList().containsExactly("field1");
-        assertThat(result.getColumn(0).getDataAsStrings()).asList().containsExactly("value");
-    }
+  private static MojoFrameBuilder frameBuilderWithMissingValues(
+      String[] columns, Type[] types, String[] missingValues) {
+    return new MojoFrameBuilder(new MojoFrameMeta(columns, types), asList(missingValues));
+  }
 
-    @Test
-    void convertNAFieldRequestWithoutMissingValues_fails() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addRowsItem(asRow("NA"));
-
-        // When & Then
-        NumberFormatException exception = assertThrows(NumberFormatException.class, () -> converter.apply(request,
-                frameBuilder(
-                        new String[]{"field1"},
-                        new Type[]{Type.Int32})));
-        assertThat(exception).hasMessageThat().contains("NA");
-    }
-
-    @Test
-    void convertNAFieldRequestWithMissingValues_succeeds() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addRowsItem(asRow("NA"));
-
-        // When
-        MojoFrame result = converter.apply(request,
-                frameBuilderWithMissingValues(
-                        new String[]{"field1"},
-                        new Type[]{Type.Int32},
-                        new String[]{"NA"})
-        );
-
-        // Then
-        assertThat(result.getNcols()).isEqualTo(1);
-        assertThat(result.getNrows()).isEqualTo(1);
-        assertThat(result.getColumnNames()).asList().containsExactly("field1");
-        assertThat(result.getColumn(0).getDataAsStrings()).asList().containsExactlyElementsIn(SINGLE_NULL);
-    }
-
-    @Test
-    void convertNullFieldRequestWithMissingValues_succeeds() {
-        // Given
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.addRowsItem(asRow(SINGLE_NULL));
-
-        // When
-        MojoFrame result = converter.apply(request,
-                frameBuilder(
-                        new String[]{"field1"},
-                        new Type[]{Type.Int32})
-        );
-
-        // Then
-        assertThat(result.getNcols()).isEqualTo(1);
-        assertThat(result.getNrows()).isEqualTo(1);
-        assertThat(result.getColumnNames()).asList().containsExactly("field1");
-        assertThat(result.getColumn(0).getDataAsStrings()).asList().containsExactlyElementsIn(SINGLE_NULL);
-    }
-
-    @Test
-    void convertMoreRowsRequest_succeeds() {
-        // Given
-        String[] values = {"value1", "value2", "value3"};
-        ScoreRequest request = new ScoreRequest();
-        request.addFieldsItem("field1");
-        request.rows(
-                Stream.of(values).map(RequestToMojoFrameConverterTest::asRow).collect(toList()));
-
-        // When
-        MojoFrame result = converter.apply(request,
-                frameBuilder(
-                        new String[]{"field1"},
-                        new Type[]{Type.Str}));
-
-        // Then
-        assertThat(result.getNcols()).isEqualTo(1);
-        assertThat(result.getNrows()).isEqualTo(3);
-        assertThat(result.getColumnNames()).asList().containsExactly("field1");
-        assertThat(result.getColumn(0).getDataAsStrings()).isEqualTo(values);
-    }
-
-    @Test
-    void convertMoreTypesRequest_succeeds() {
-        // Given
-        Type[] types = {Type.Str, Type.Float32, Type.Float64, Type.Bool, Type.Int32, Type.Int64};
-        List<String> fields = Stream.of(types).map(Object::toString).collect(toList());
-        String[] values = {"str", "1.1", "2.2", "1", "123", "123456789"};
-        ScoreRequest request = new ScoreRequest();
-        request.setFields(fields);
-        request.addRowsItem(asRow(values));
-
-        // When
-        MojoFrame result = converter.apply(request,
-                frameBuilder(fields.toArray(new String[0]), types));
-
-        // Then
-        assertThat(result.getNcols()).isEqualTo(types.length);
-        assertThat(result.getNrows()).isEqualTo(1);
-        assertThat(result.getColumnNames()).asList().containsExactlyElementsIn(fields);
-        for (int col = 0; col < types.length; col++) {
-            assertThat(result.getColumn(col).getDataAsStrings()[0]).isEqualTo(values[col]);
-        }
-    }
-
-    private static MojoFrameBuilder emptyFrameBuilder() {
-        return new MojoFrameBuilder(MojoFrameMeta.getEmpty());
-    }
-
-    private static MojoFrameBuilder frameBuilder(String[] columns, Type[] types) {
-        return new MojoFrameBuilder(new MojoFrameMeta(columns, types));
-    }
-
-    private static MojoFrameBuilder frameBuilderWithMissingValues(String[] columns, Type[] types,
-                                                                  String[] missingValues) {
-        return new MojoFrameBuilder(new MojoFrameMeta(columns, types), asList(missingValues));
-    }
-
-    private static Row asRow(String... values) {
-        Row row = new Row();
-        row.ensureCapacity(values.length);
-        row.addAll(asList(values));
-        return row;
-    }
+  private static Row asRow(String... values) {
+    Row row = new Row();
+    row.ensureCapacity(values.length);
+    row.addAll(asList(values));
+    return row;
+  }
 }

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilderTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilderTest.java
@@ -1,5 +1,6 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilderTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/SampleRequestBuilderTest.java
@@ -1,76 +1,78 @@
 package ai.h2o.mojos.deploy.common.transform;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.runtime.frame.MojoColumn;
 import ai.h2o.mojos.runtime.frame.MojoFrameMeta;
-import org.junit.jupiter.api.Test;
-
 import java.util.stream.Stream;
-
-import static com.google.common.truth.Truth.assertThat;
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import org.junit.jupiter.api.Test;
 
 class SampleRequestBuilderTest {
 
-    private final SampleRequestBuilder builder = new SampleRequestBuilder();
+  private final SampleRequestBuilder builder = new SampleRequestBuilder();
 
-    @Test
-    void build_EmptyMeta() {
-        // Given
-        MojoFrameMeta inputMeta = new MojoFrameMeta(new String[]{}, new MojoColumn.Type[]{});
+  @Test
+  void build_EmptyMeta() {
+    // Given
+    MojoFrameMeta inputMeta = new MojoFrameMeta(new String[] {}, new MojoColumn.Type[] {});
 
-        // When
-        ScoreRequest result = builder.build(inputMeta);
+    // When
+    ScoreRequest result = builder.build(inputMeta);
 
-        // Then
-        ScoreRequest expected = new ScoreRequest();
-        expected.fields(emptyList());
-        expected.addRowsItem(asRow());
-        assertThat(result).isEqualTo(expected);
-    }
+    // Then
+    ScoreRequest expected = new ScoreRequest();
+    expected.fields(emptyList());
+    expected.addRowsItem(asRow());
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    void build_OneField() {
-        // Given
-        MojoFrameMeta inputMeta = new MojoFrameMeta(
-                new String[]{"field"},
-                new MojoColumn.Type[]{MojoColumn.Type.Str});
+  @Test
+  void build_OneField() {
+    // Given
+    MojoFrameMeta inputMeta =
+        new MojoFrameMeta(new String[] {"field"}, new MojoColumn.Type[] {MojoColumn.Type.Str});
 
-        // When
-        ScoreRequest result = builder.build(inputMeta);
+    // When
+    ScoreRequest result = builder.build(inputMeta);
 
-        // Then
-        ScoreRequest expected = new ScoreRequest();
-        expected.addFieldsItem("field");
-        expected.addRowsItem(asRow("text"));
-        assertThat(result).isEqualTo(expected);
-    }
+    // Then
+    ScoreRequest expected = new ScoreRequest();
+    expected.addFieldsItem("field");
+    expected.addRowsItem(asRow("text"));
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    void build_AllTypes() {
-        // Given
-        MojoColumn.Type[] types = {
-                MojoColumn.Type.Str, MojoColumn.Type.Float32, MojoColumn.Type.Float64, MojoColumn.Type.Bool,
-                MojoColumn.Type.Int32, MojoColumn.Type.Int64, MojoColumn.Type.Time64};
-        String[] columns = Stream.of(types).map(Object::toString).toArray(String[]::new);
-        MojoFrameMeta inputMeta = new MojoFrameMeta(columns, types);
+  @Test
+  void build_AllTypes() {
+    // Given
+    MojoColumn.Type[] types = {
+      MojoColumn.Type.Str,
+      MojoColumn.Type.Float32,
+      MojoColumn.Type.Float64,
+      MojoColumn.Type.Bool,
+      MojoColumn.Type.Int32,
+      MojoColumn.Type.Int64,
+      MojoColumn.Type.Time64
+    };
+    String[] columns = Stream.of(types).map(Object::toString).toArray(String[]::new);
+    MojoFrameMeta inputMeta = new MojoFrameMeta(columns, types);
 
-        // When
-        ScoreRequest result = builder.build(inputMeta);
+    // When
+    ScoreRequest result = builder.build(inputMeta);
 
-        // Then
-        ScoreRequest expected = new ScoreRequest();
-        expected.fields(asList(columns));
-        expected.addRowsItem((asRow("text", "0", "0", "true", "0", "0", "2018-01-01")));
-        assertThat(result).isEqualTo(expected);
-    }
+    // Then
+    ScoreRequest expected = new ScoreRequest();
+    expected.fields(asList(columns));
+    expected.addRowsItem((asRow("text", "0", "0", "true", "0", "0", "2018-01-01")));
+    assertThat(result).isEqualTo(expected);
+  }
 
-    private static Row asRow(String... values) {
-        Row row = new Row();
-        row.addAll(asList(values));
-        return row;
-    }
+  private static Row asRow(String... values) {
+    Row row = new Row();
+    row.addAll(asList(values));
+    return row;
+  }
 }

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/ScorerApplication.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/ScorerApplication.java
@@ -7,7 +7,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @SpringBootApplication
 @EnableSwagger2
 public class ScorerApplication {
-    public static void main(String[] args) {
-        new SpringApplication(ScorerApplication.class).run(args);
-    }
+  public static void main(String[] args) {
+    new SpringApplication(ScorerApplication.class).run(args);
+  }
 }

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
@@ -10,28 +10,28 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 class ScorerConfiguration {
-    @Bean
-    public MojoFrameToResponseConverter responseConverter() {
-        return new MojoFrameToResponseConverter();
-    }
+  @Bean
+  public MojoFrameToResponseConverter responseConverter() {
+    return new MojoFrameToResponseConverter();
+  }
 
-    @Bean
-    public RequestToMojoFrameConverter requestConverter() {
-        return new RequestToMojoFrameConverter();
-    }
+  @Bean
+  public RequestToMojoFrameConverter requestConverter() {
+    return new RequestToMojoFrameConverter();
+  }
 
-    @Bean
-    public MojoPipelineToModelInfoConverter modelConverter() {
-        return new MojoPipelineToModelInfoConverter();
-    }
+  @Bean
+  public MojoPipelineToModelInfoConverter modelConverter() {
+    return new MojoPipelineToModelInfoConverter();
+  }
 
-    @Bean
-    public CsvToMojoFrameConverter csvConverter() {
-        return new CsvToMojoFrameConverter();
-    }
+  @Bean
+  public CsvToMojoFrameConverter csvConverter() {
+    return new CsvToMojoFrameConverter();
+  }
 
-    @Bean
-    public SampleRequestBuilder sampleRequestBuilder() {
-        return new SampleRequestBuilder();
-    }
+  @Bean
+  public SampleRequestBuilder sampleRequestBuilder() {
+    return new SampleRequestBuilder();
+  }
 }

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -1,102 +1,101 @@
 package ai.h2o.mojos.deploy.local.rest.controller;
 
+import static java.util.Collections.singletonList;
+
 import ai.h2o.mojos.deploy.common.rest.api.ModelsApi;
 import ai.h2o.mojos.deploy.common.rest.model.Model;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
 import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
 import com.google.common.base.Strings;
+import java.io.IOException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
-import java.io.IOException;
-import java.util.List;
-
-import static java.util.Collections.singletonList;
-
 @Controller
 public class ModelsApiController implements ModelsApi {
 
-    private static final Logger log = LoggerFactory.getLogger(ModelsApiController.class);
+  private static final Logger log = LoggerFactory.getLogger(ModelsApiController.class);
 
-    private final MojoScorer scorer;
-    private final SampleRequestBuilder sampleRequestBuilder;
+  private final MojoScorer scorer;
+  private final SampleRequestBuilder sampleRequestBuilder;
 
-    @Autowired
-    public ModelsApiController(MojoScorer scorer, SampleRequestBuilder sampleRequestBuilder) {
-        this.scorer = scorer;
-        this.sampleRequestBuilder = sampleRequestBuilder;
+  @Autowired
+  public ModelsApiController(MojoScorer scorer, SampleRequestBuilder sampleRequestBuilder) {
+    this.scorer = scorer;
+    this.sampleRequestBuilder = sampleRequestBuilder;
+  }
+
+  public ResponseEntity<Model> getModelInfo(String id) {
+    if (Strings.isNullOrEmpty(id)) {
+      log.info("Request is missing a valid id");
+      return ResponseEntity.badRequest().build();
     }
-
-    public ResponseEntity<Model> getModelInfo(String id) {
-        if (Strings.isNullOrEmpty(id)) {
-            log.info("Request is missing a valid id");
-            return ResponseEntity.badRequest().build();
-        }
-        if (!id.equals(scorer.getModelId())) {
-            log.info("Model {} not found", id);
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(scorer.getModelInfo());
+    if (!id.equals(scorer.getModelId())) {
+      log.info("Model {} not found", id);
+      return ResponseEntity.notFound().build();
     }
+    return ResponseEntity.ok(scorer.getModelInfo());
+  }
 
-    public ResponseEntity<List<String>> getModels() {
-        return ResponseEntity.ok(singletonList(scorer.getModelId()));
-    }
+  public ResponseEntity<List<String>> getModels() {
+    return ResponseEntity.ok(singletonList(scorer.getModelId()));
+  }
 
-    public ResponseEntity<ScoreResponse> getScore(ScoreRequest request, String id) {
-        if (Strings.isNullOrEmpty(id)) {
-            log.info("Request is missing a valid id");
-            return ResponseEntity.badRequest().build();
-        }
-        if (!id.equals(scorer.getModelId())) {
-            log.info("Model {} not found", id);
-            return ResponseEntity.notFound().build();
-        }
-        try {
-            return ResponseEntity.ok(scorer.score(request));
-        } catch (Exception e) {
-            log.info("Failed scoring request: {}, due to: {}", request, e.getMessage());
-            log.debug(" - failure cause: ", e);
-            return ResponseEntity.badRequest().build();
-        }
+  public ResponseEntity<ScoreResponse> getScore(ScoreRequest request, String id) {
+    if (Strings.isNullOrEmpty(id)) {
+      log.info("Request is missing a valid id");
+      return ResponseEntity.badRequest().build();
     }
+    if (!id.equals(scorer.getModelId())) {
+      log.info("Model {} not found", id);
+      return ResponseEntity.notFound().build();
+    }
+    try {
+      return ResponseEntity.ok(scorer.score(request));
+    } catch (Exception e) {
+      log.info("Failed scoring request: {}, due to: {}", request, e.getMessage());
+      log.debug(" - failure cause: ", e);
+      return ResponseEntity.badRequest().build();
+    }
+  }
 
-    public ResponseEntity<ScoreResponse> getScoreByFile(String id, String file) {
-        if (Strings.isNullOrEmpty(id)) {
-            log.info("Request is missing a valid id");
-            return ResponseEntity.badRequest().build();
-        }
-        if (Strings.isNullOrEmpty(file)) {
-            log.info("Request is missing a valid CSV file path");
-            return ResponseEntity.badRequest().build();
-        }
-        if (!id.equals(scorer.getModelId())) {
-            log.info("Model {} not found", id);
-            return ResponseEntity.notFound().build();
-        }
-        try {
-            return ResponseEntity.ok(scorer.scoreCsv(file));
-        } catch (IOException e) {
-            log.info("Failed loading CSV file: {}, due to: {}", file, e.getMessage());
-            log.debug(" - failure cause: ", e);
-            return ResponseEntity.badRequest().build();
-        } catch (Exception e) {
-            log.info("Failed scoring CSV file: {}, due to: {}", file, e.getMessage());
-            log.debug(" - failure cause: ", e);
-            return ResponseEntity.badRequest().build();
-        }
+  public ResponseEntity<ScoreResponse> getScoreByFile(String id, String file) {
+    if (Strings.isNullOrEmpty(id)) {
+      log.info("Request is missing a valid id");
+      return ResponseEntity.badRequest().build();
     }
+    if (Strings.isNullOrEmpty(file)) {
+      log.info("Request is missing a valid CSV file path");
+      return ResponseEntity.badRequest().build();
+    }
+    if (!id.equals(scorer.getModelId())) {
+      log.info("Model {} not found", id);
+      return ResponseEntity.notFound().build();
+    }
+    try {
+      return ResponseEntity.ok(scorer.scoreCsv(file));
+    } catch (IOException e) {
+      log.info("Failed loading CSV file: {}, due to: {}", file, e.getMessage());
+      log.debug(" - failure cause: ", e);
+      return ResponseEntity.badRequest().build();
+    } catch (Exception e) {
+      log.info("Failed scoring CSV file: {}, due to: {}", file, e.getMessage());
+      log.debug(" - failure cause: ", e);
+      return ResponseEntity.badRequest().build();
+    }
+  }
 
-    @Override
-    public ResponseEntity<ScoreRequest> getSampleRequest(String id) {
-        if (!id.equals(scorer.getModelId())) {
-            log.info("Model {} not found", id);
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(sampleRequestBuilder.build(scorer.getPipeline().getInputMeta()));
+  @Override
+  public ResponseEntity<ScoreRequest> getSampleRequest(String id) {
+    if (!id.equals(scorer.getModelId())) {
+      log.info("Model {} not found", id);
+      return ResponseEntity.notFound().build();
     }
+    return ResponseEntity.ok(sampleRequestBuilder.build(scorer.getPipeline().getInputMeta()));
+  }
 }


### PR DESCRIPTION
Run google-java-format (https://github.com/google/google-java-format) on the (non-KDB) code base.
Should only be whitespace and import reordering changes.

Will enable automated check as part of gradle build in a separate PR.

Why Google format?
 - It is not too permissive giving us the chance to focus on what really matters: code.
 - Supported in IDEs and build systems (mvn, gradle)
 - Me and @zoido are quite used to it already.
 - I quite like it :).