### PR TITLE
Restructure Gradle files

### DIFF
--- a/aws-lambda-scorer/lambda-template/build.gradle
+++ b/aws-lambda-scorer/lambda-template/build.gradle
@@ -3,7 +3,6 @@ apply from: project(":").file('gradle/java.gradle')
 dependencies {
     implementation project(':common:rest-java-model')
     implementation project(':common:transform')
-
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-core'
@@ -39,4 +38,3 @@ rootProject.distributionZip {
         from buildZip.archivePath
     }
 }
-

--- a/aws-lambda-scorer/lambda-template/build.gradle
+++ b/aws-lambda-scorer/lambda-template/build.gradle
@@ -1,17 +1,19 @@
+apply from: project(":").file('gradle/java.gradle')
+
 dependencies {
-    compile project(':common:rest-java-model')
-    compile project(':common:transform')
+    implementation project(':common:rest-java-model')
+    implementation project(':common:transform')
 
-    compile group: 'ai.h2o', name: 'mojo2-runtime-api'
-    compile group: 'ai.h2o', name: 'mojo2-runtime-impl'
-    compile group: 'com.amazonaws', name: 'aws-lambda-java-core'
-    compile group: 'com.amazonaws', name: 'aws-lambda-java-events'
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3'
-    compile group: 'com.google.code.gson', name: 'gson'
-    compile group: 'io.swagger.core.v3', name: 'swagger-annotations'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    implementation group: 'com.amazonaws', name: 'aws-lambda-java-core'
+    implementation group: 'com.amazonaws', name: 'aws-lambda-java-events'
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3'
+    implementation group: 'com.google.code.gson', name: 'gson'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations'
 
-    testCompile group: 'com.google.truth.extensions', name: 'truth-java8-extension'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,66 +20,6 @@ subprojects {
     repositories {
         mavenCentral()
     }
-
-    apply plugin: 'java'
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
-
-    apply plugin: 'io.spring.dependency-management'
-    dependencyManagement {
-        dependencies {
-            dependencySet(group: 'ai.h2o', version: mojoRuntimeVersion) {
-                entry 'mojo2-runtime-api'
-                entry 'mojo2-runtime-impl'
-            }
-            dependency group: 'com.amazonaws', name: 'aws-lambda-java-core', version: awsLambdaCoreVersion
-            dependency group: 'com.amazonaws', name: 'aws-lambda-java-events', version: awsLambdaEventsVersion
-            dependency group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: awsSdkS3Version
-            dependency group: 'com.google.code.gson', name: 'gson', version: gsonVersion
-            dependency group: 'com.google.truth.extensions', name: 'truth-java8-extension', version: truthVersion
-            dependencySet(group: 'io.springfox', version: springFoxVersion) {
-                entry 'springfox-swagger2'
-                entry 'springfox-swagger-ui'
-            }
-            dependency group: 'io.swagger', name: 'swagger-annotations', version: swaggerCoreSpringVersion
-            dependency group: 'io.swagger.core.v3', name: 'swagger-annotations', version: swaggerCoreVersion
-            dependency group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli', version: swaggerCodegenVersion
-            dependency group: 'javax.annotation', name: 'javax.annotation-api', version: javaxAnnotationVersion
-            dependencySet(group: 'org.junit.jupiter', version: jupiterVersion) {
-                entry 'junit-jupiter-api'
-                entry 'junit-jupiter-engine'
-            }
-            dependencySet(group: 'org.mockito', version: mockitoVersion) {
-                entry 'mockito-core'
-                entry 'mockito-junit-jupiter'
-            }
-            dependency group: 'commons-cli', name: 'commons-cli', version: apacheCommonsCliVersion
-            dependency group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
-        }
-    }
-
-    apply plugin: 'com.diffplug.gradle.spotless'
-    spotless {
-        java {
-            target project.fileTree(project.rootDir) {
-                include '**/*.java'
-                // Exclude generated and hidden folders.
-                exclude '**/.*/**'
-                exclude '**/build/**'
-                // Exclude KDB related code.
-                exclude '**/kdb-java/**'
-                exclude '**/kdb-mojo-scorer/**'
-            }
-            googleJavaFormat('1.7')
-        }
-    }
-
-    apply plugin: 'checkstyle'
-    checkstyle {
-        toolVersion '8.21'
-        configFile = project(":").file("config/checkstyle/google_style.xml")
-        configProperties = ["suppressionFile": project(":").file("config/checkstyle/suppressions.xml")]
-    }
 }
 
 // Collect artifacts from all the deployment templates into a single ZIP to be released.

--- a/common/kdb-java/build.gradle
+++ b/common/kdb-java/build.gradle
@@ -2,6 +2,7 @@ apply from: project(":").file('gradle/java_no_style.gradle')
 
 dependencies {
     implementation group: 'com.google.code.gson', name: 'gson'
+
     testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine'

--- a/common/kdb-java/build.gradle
+++ b/common/kdb-java/build.gradle
@@ -1,7 +1,9 @@
+apply from: project(":").file('gradle/java_no_style.gradle')
+
 dependencies {
-    compile group: 'com.google.code.gson', name: 'gson'
-    testCompile group: 'com.google.truth.extensions', name: 'truth-java8-extension'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    implementation group: 'com.google.code.gson', name: 'gson'
+    testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
 }
 

--- a/common/rest-java-model/build.gradle
+++ b/common/rest-java-model/build.gradle
@@ -1,9 +1,12 @@
-apply plugin: 'org.hidetake.swagger.generator'
+plugins {
+    id 'org.hidetake.swagger.generator'
+}
+apply from: project(":").file('gradle/java.gradle')
 
 dependencies {
-    compile group: 'com.google.code.gson', name: 'gson'
-    compile group: 'javax.annotation', name: 'javax.annotation-api'
-    compile group: 'io.swagger.core.v3', name: 'swagger-annotations'
+    implementation group: 'com.google.code.gson', name: 'gson'
+    implementation group: 'javax.annotation', name: 'javax.annotation-api'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations'
     swaggerCodegen group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli'
 }
 

--- a/common/rest-spring-api/build.gradle
+++ b/common/rest-spring-api/build.gradle
@@ -1,9 +1,12 @@
-apply plugin: 'org.springframework.boot'
-apply plugin: 'org.hidetake.swagger.generator'
+plugins {
+    id 'org.springframework.boot'
+    id 'org.hidetake.swagger.generator'
+}
+apply from: project(":").file('gradle/java.gradle')
 
 dependencies {
-    compile group: 'io.swagger', name: 'swagger-annotations'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    implementation group: 'io.swagger', name: 'swagger-annotations'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     swaggerCodegen group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli'
 }
 

--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -1,13 +1,15 @@
+apply from: project(":").file('gradle/java.gradle')
+
 dependencies {
-    compile project(':common:rest-java-model')
+    implementation project(':common:rest-java-model')
 
-    compile group: 'ai.h2o', name: 'mojo2-runtime-api'
-    compile group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
 
-    testCompile group: 'com.google.truth.extensions', name: 'truth-java8-extension'
-    testCompile group: 'org.mockito', name: 'mockito-core'
-    testCompile group: 'org.mockito', name: 'mockito-junit-jupiter'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
 }
 

--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -2,7 +2,6 @@ apply from: project(":").file('gradle/java.gradle')
 
 dependencies {
     implementation project(':common:rest-java-model')
-
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -6,7 +6,4 @@
 
 <suppressions>
     <suppress files="[/\\]build[/\\]" checks=".*"/>
-    <!-- Suppress style violation in KDB code -->
-    <suppress files="[/\\]kdb-mojo-scorer[/\\]" checks=".*"/>
-    <suppress files="[/\\]kdb-java[/\\]" checks=".*"/>
 </suppressions>

--- a/docker/local-rest-scorer/build.gradle
+++ b/docker/local-rest-scorer/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.bmuschko.docker-remote-api'
+plugins {
+    id 'com.bmuschko.docker-remote-api'
+}
 
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
@@ -14,4 +16,6 @@ task buildDockerImage(type: DockerBuildImage) {
     inputDir = file('.')
     tags.add('h2oai/rest-scorer:' + version)
 }
-build.dependsOn buildDockerImage
+
+// Plug into the gradle build process
+task build dependsOn buildDockerImage

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,7 @@ springBootPluginVersion = 2.1.1.RELEASE
 swaggerGradlePluginVersion = 2.15.1
 dockerPluginVersion = 4.10.0
 spotlessPluginVersion = 3.24.2
+
+# External tools:
+checkStyleVersion = 8.21
+googleJavaFormatVersion = 1.7

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,0 +1,6 @@
+// Defines shared aspects of a Gradle Java module with style/format checking.
+
+apply from: project(":").file('gradle/java_no_style.gradle')
+
+apply from: project(":").file('gradle/mixins/checkstyle.gradle')
+apply from: project(":").file('gradle/mixins/spotless.gradle')

--- a/gradle/java_no_style.gradle
+++ b/gradle/java_no_style.gradle
@@ -1,0 +1,9 @@
+// Defines shared aspects of a Gradle Java module without style/format checking.
+//
+// NOTE: Only use with a good reason to, e.g., for vendored code. Otherwise, please prefer `gradle/java.gradle`.
+
+apply plugin: 'java'
+apply from: project(":").file('gradle/mixins/dependencies.gradle')
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8

--- a/gradle/mixins/checkstyle.gradle
+++ b/gradle/mixins/checkstyle.gradle
@@ -3,7 +3,7 @@
 apply plugin: 'checkstyle'
 
 checkstyle {
-    toolVersion '8.21'
+    toolVersion checkStyleVersion
     configFile = project(":").file("config/checkstyle/google_style.xml")
     configProperties = ["suppressionFile": project(":").file("config/checkstyle/suppressions.xml")]
 }

--- a/gradle/mixins/checkstyle.gradle
+++ b/gradle/mixins/checkstyle.gradle
@@ -1,0 +1,9 @@
+// Defines shared Gradle project Checkstyle analyzer configuration.
+
+apply plugin: 'checkstyle'
+
+checkstyle {
+    toolVersion '8.21'
+    configFile = project(":").file("config/checkstyle/google_style.xml")
+    configProperties = ["suppressionFile": project(":").file("config/checkstyle/suppressions.xml")]
+}

--- a/gradle/mixins/dependencies.gradle
+++ b/gradle/mixins/dependencies.gradle
@@ -1,0 +1,35 @@
+// Defines shared aspects of Spring dependency management.
+
+apply plugin: 'io.spring.dependency-management'
+
+dependencyManagement {
+    dependencies {
+        dependencySet(group: 'ai.h2o', version: mojoRuntimeVersion) {
+            entry 'mojo2-runtime-api'
+            entry 'mojo2-runtime-impl'
+        }
+        dependency group: 'com.amazonaws', name: 'aws-lambda-java-core', version: awsLambdaCoreVersion
+        dependency group: 'com.amazonaws', name: 'aws-lambda-java-events', version: awsLambdaEventsVersion
+        dependency group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: awsSdkS3Version
+        dependency group: 'com.google.code.gson', name: 'gson', version: gsonVersion
+        dependency group: 'com.google.truth.extensions', name: 'truth-java8-extension', version: truthVersion
+        dependencySet(group: 'io.springfox', version: springFoxVersion) {
+            entry 'springfox-swagger2'
+            entry 'springfox-swagger-ui'
+        }
+        dependency group: 'io.swagger', name: 'swagger-annotations', version: swaggerCoreSpringVersion
+        dependency group: 'io.swagger.core.v3', name: 'swagger-annotations', version: swaggerCoreVersion
+        dependency group: 'io.swagger.codegen.v3', name: 'swagger-codegen-cli', version: swaggerCodegenVersion
+        dependency group: 'javax.annotation', name: 'javax.annotation-api', version: javaxAnnotationVersion
+        dependencySet(group: 'org.junit.jupiter', version: jupiterVersion) {
+            entry 'junit-jupiter-api'
+            entry 'junit-jupiter-engine'
+        }
+        dependencySet(group: 'org.mockito', version: mockitoVersion) {
+            entry 'mockito-core'
+            entry 'mockito-junit-jupiter'
+        }
+        dependency group: 'commons-cli', name: 'commons-cli', version: apacheCommonsCliVersion
+        dependency group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
+    }
+}

--- a/gradle/mixins/spotless.gradle
+++ b/gradle/mixins/spotless.gradle
@@ -1,0 +1,12 @@
+// Defines shared Gradle project Spotless formatter configuration.
+
+apply plugin: 'com.diffplug.gradle.spotless'
+
+spotless {
+    java {
+        target fileTree('src') {
+            include '**/*.java'
+        }
+        googleJavaFormat('1.7')
+    }
+}

--- a/gradle/mixins/spotless.gradle
+++ b/gradle/mixins/spotless.gradle
@@ -7,6 +7,6 @@ spotless {
         target fileTree('src') {
             include '**/*.java'
         }
-        googleJavaFormat('1.7')
+        googleJavaFormat(googleJavaFormatVersion)
     }
 }

--- a/kdb-mojo-scorer/build.gradle
+++ b/kdb-mojo-scorer/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
     implementation group: 'commons-cli', name: 'commons-cli'
     implementation group: 'org.slf4j', name: 'slf4j-log4j12'
+
     testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine'

--- a/kdb-mojo-scorer/build.gradle
+++ b/kdb-mojo-scorer/build.gradle
@@ -1,13 +1,16 @@
-apply plugin: 'com.github.johnrengelman.shadow'
+plugins {
+    id 'com.github.johnrengelman.shadow'
+}
+apply from: project(":").file('gradle/java_no_style.gradle')
 
 dependencies {
-    compile project(':common:kdb-java')
-    compile group: 'ai.h2o', name: 'mojo2-runtime-api'
-    compile group: 'ai.h2o', name: 'mojo2-runtime-impl'
-    compile group: 'commons-cli', name: 'commons-cli'
-    compile group: 'org.slf4j', name: 'slf4j-log4j12'
-    testCompile group: 'com.google.truth.extensions', name: 'truth-java8-extension'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    implementation project(':common:kdb-java')
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    implementation group: 'commons-cli', name: 'commons-cli'
+    implementation group: 'org.slf4j', name: 'slf4j-log4j12'
+    testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
 }
 

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -6,7 +6,6 @@ apply from: project(":").file('gradle/java.gradle')
 dependencies {
     implementation project(':common:rest-spring-api')
     implementation project(':common:transform')
-
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
     implementation group: 'io.springfox', name: 'springfox-swagger2'

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -1,14 +1,17 @@
-apply plugin: 'org.springframework.boot'
+plugins {
+    id 'org.springframework.boot'
+}
+apply from: project(":").file('gradle/java.gradle')
 
 dependencies {
-    compile project(':common:rest-spring-api')
-    compile project(':common:transform')
+    implementation project(':common:rest-spring-api')
+    implementation project(':common:transform')
 
-    compile group: 'ai.h2o', name: 'mojo2-runtime-api'
-    compile group: 'ai.h2o', name: 'mojo2-runtime-impl'
-    compile group: 'io.springfox', name: 'springfox-swagger2'
-    compile group: 'io.springfox', name: 'springfox-swagger-ui'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    implementation group: 'io.springfox', name: 'springfox-swagger2'
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
 }
 
 test {


### PR DESCRIPTION
This is a follow up on @orendain comments in: https://github.com/h2oai/dai-deployment-templates/pull/105.

Turns out some of the comments cannot be implemented without having a lot of code copy&pasted around. E.g. `plugins` cannot be used anywhere except as the first part of a (sub)project gradle file. I want to prevent copying the shared configuration around as it is then hard to keep in sync. The result is that I still use the old way of enabling plugins where needed.

However the comments lead me to try a different way of structuring the gradle files. Please have a look and comment heavily. Maybe you won't find it better, in which case I am happy to drop the PR.

Things I personally like now are:
- it is possible to look at the subproject gradle file and see where stuff is defined (as the `apply from:` now work as sort of includes).
- separate stuff is in separate files, making the root gradle file much simpler.
- no need for central KDB related exclusions as this is now achieved by the kdb subprojects not using the style mixins (explicitely via `aplyt from: ... _no_style.gradle`).

Thoughts?