### PR TITLE
Push docker images to harbor on master and release branches.

### DIFF
--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -40,7 +40,7 @@ jib {
         image = 'openjdk:8-jre-alpine'
     }
     to {
-        image = 'harbor.h2o.ai/h2oai/rest-scorer'
+        image = 'harbor.h2o.ai/opsh2oai/h2oai/rest-scorer'
         tags = [version]
     }
     container {


### PR DESCRIPTION
Enable pushing docker images to Harbor for `master` and `release-*` branches or when explicitly requested by setting the PUSH_DOCKER_IMAGES pipeline parameter.

Part of https://github.com/h2oai/h2oai-serving/issues/262.