### PR TITLE
Remove model ID from the endpoint paths.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ hs_err_pid*
 
 # Intermediate build files and folders.
 build/
+out/
 .gradle/
 .terraform/
 terraform.tfstate*

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -144,8 +144,6 @@ definitions:
   ScoreRequest:
     type: object
     properties:
-      id:
-        type: string
       includeFieldsInOutput:
         type: array
         items:

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -25,7 +25,7 @@ paths:
       description: Returns unique id of the model loaded in the server and used for scoring
       operationId: getModelId
       produces:
-        - application/json
+        - text/plain
       parameters: []
       responses:
         '200':

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -53,8 +53,8 @@ paths:
     get:
       tags:
         - metadata
-      summary: sample scoring request
-      description: builds a sample scoring request that would pass all validations
+      summary: Sample scoring request
+      description: Builds a sample scoring request that would pass all validations
       operationId: getSampleRequest
       produces:
         - application/json

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -17,86 +17,65 @@ schemes:
   - https
   - http
 paths:
-  /models:
+  /model/id:
     get:
       tags:
-        - models
-      summary: Returns a list of models loaded in the server
-      description: Returns a list of models loaded in the server
-      operationId: getModels
+        - metadata
+      summary: Returns model id
+      description: Returns unique id of the model loaded in the server and used for scoring
+      operationId: getModelId
       produces:
         - application/json
       parameters: []
       responses:
         '200':
-          description: list of model ids that are available to score
+          description: Successful operation
           schema:
-            type: array
-            items:
-              type: string
+            type: string
       security:
         - api_key: []
-  '/models/{id}':
+  '/model/schema':
     get:
       tags:
-        - models
-      summary: describe a model
-      description: describe a model
+        - metadata
+      summary: Describe a model
+      description: Returns information about the model used for scoring, e.g., input schema.
       operationId: getModelInfo
       produces:
         - application/json
-      parameters:
-        - name: id
-          in: path
-          description: unique model identifier
-          required: true
-          type: string
+      parameters: []
       responses:
         '200':
-          description: successful operation
+          description: Successful operation
           schema:
             $ref: '#/definitions/Model'
-        '404':
-          description: 'Model not found, please verify model id'
-  '/models/{id}/sample_request':
+  '/model/sample_request':
     get:
       tags:
-        - models
+        - metadata
       summary: sample scoring request
       description: builds a sample scoring request that would pass all validations
       operationId: getSampleRequest
       produces:
         - application/json
-      parameters:
-        - name: id
-          in: path
-          description: unique model identifier
-          required: true
-          type: string
+      parameters: []
       responses:
         '200':
-          description: successful operation
+          description: Successful operation
           schema:
             $ref: '#/definitions/ScoreRequest'
-        '404':
-          description: 'Model not found, please verify model id'
-  '/models/{id}/score':
+  '/model/score':
     post:
       tags:
-        - models
-      summary: score a model
-      description: score a model
+        - scoring
+      summary: Score on given rows
+      description: Computes score of the rows sent in the body of the post request
       operationId: getScore
       consumes:
         - application/json
       produces:
         - application/json
       parameters:
-        - name: id
-          in: path
-          description: ID of model to be scored
-          required: true
-          type: string
         - name: payload
           in: body
           required: true
@@ -104,39 +83,30 @@ paths:
             $ref: '#/definitions/ScoreRequest'
       responses:
         '200':
-          description: successful operation
+          description: Successful operation
           schema:
             $ref: '#/definitions/ScoreResponse'
         '400':
           description: Invalid payload
-        '404':
-          description: Model not found
     get:
       tags:
-        - models
-      summary: score a model
-      description: score a model
+        - scoring
+      summary: Score on given file
+      description: Computes score of the rows in the file specified by the path in the query parameter
       operationId: getScoreByFile
       produces:
         - application/json
       parameters:
-        - in: path
-          name: id
-          description: ID of model to be scored
-          required: true
-          type: string
         - in: query
           name: file
           type: string
       responses:
         '200':
-          description: successful operation
+          description: Successful operation
           schema:
             $ref: '#/definitions/ScoreResponse'
         '400':
           description: Invalid payload
-        '404':
-          description: Model not found
 securityDefinitions:
   api_key:
     type: apiKey

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.2.10-SNAPSHOT
+version = 1.0.0-SNAPSHOT
 
 # Versions of dependencies. Try to keep these at the same version across the deployment templates to facilitate
 # issue resolution.

--- a/local-rest-scorer/README.md
+++ b/local-rest-scorer/README.md
@@ -26,20 +26,8 @@ To test the endpoint, send a request to http://localhost:8080 as follows:
 curl \
     -X POST \
     -H "Content-Type: application/json" \
-    -d @test.json http://localhost:8080/models/{UUID_OF_YOUR_MOJO_PIPELINE}/score
+    -d @test.json http://localhost:8080/model/score
 ```
-
-You can get the UUID of the loaded pipeline by calling the following:
-
-```bash
-$ curl http://localhost:8080/models
-```
-
-Which should return a json list with the UUID.
-
-Alternatively, the scorer log contains the UUID as well in the form:
-`Mojo pipeline successfully loaded (a12e7390-b8ac-406a-ade9-0d5ea4b63ea9).`
-The hex string in parenthesis is the UUID of you mojo pipeline.
 
 This expects a file `test.json` with the actual scoring request payload.
 If you are using the mojo trained in `test/data/iris.csv` as suggested above,
@@ -99,13 +87,25 @@ The expected response should follow this structure, but the actual values may di
 Alternatively, you can score an existing file on the local filesystem using `GET` request to the same endpoint:
 
 ```bash
-curl \
-    -X GET \
-    http://localhost:8080/models/{UUID_OF_YOUR_MOJO_PIPELINE}/score/?file=/tmp/test.csv
+curl -X GET http://localhost:8080/model/score/?file=/tmp/test.csv
 ```
 
 This expects a CSV file `/tmp/test.csv` to exist on the machine where the scorer runs (i.e., it is not send to it
 over HTTP).
+
+### Model ID
+
+You can get the UUID of the loaded pipeline by calling the following:
+
+```bash
+$ curl http://localhost:8080/model/id
+```
+
+Which should return the UUID of the loaded mojo model.
+
+Alternatively, the scorer log contains the UUID as well in the form:
+`Mojo pipeline successfully loaded (a12e7390-b8ac-406a-ade9-0d5ea4b63ea9).`
+The hex string in parenthesis is the UUID of you mojo pipeline.
 
 ### Get Example Request
 
@@ -114,12 +114,10 @@ This way, users can quickly get an example scoring request to send to the scorer
 This request can be further filled with meaningful input values.
 
 ```bash
-curl \
-    -X GET \
-    http://localhost:8080/models/{UUID_OF_YOUR_MOJO_PIPELINE}/sample_request
+curl -X GET http://localhost:8080/model/sample_request
 ```
 
-The resulting JSON is a valid input for the POST `/score` request.
+The resulting JSON is a valid input for the POST `/model/score` request.
 
 ### API Inspection
 

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -1,15 +1,12 @@
 package ai.h2o.mojos.deploy.local.rest.controller;
 
-import static java.util.Collections.singletonList;
-
-import ai.h2o.mojos.deploy.common.rest.api.ModelsApi;
+import ai.h2o.mojos.deploy.common.rest.api.ModelApi;
 import ai.h2o.mojos.deploy.common.rest.model.Model;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
 import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
 import com.google.common.base.Strings;
 import java.io.IOException;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
-public class ModelsApiController implements ModelsApi {
+public class ModelsApiController implements ModelApi {
 
   private static final Logger log = LoggerFactory.getLogger(ModelsApiController.class);
 
@@ -31,33 +28,17 @@ public class ModelsApiController implements ModelsApi {
   }
 
   @Override
-  public ResponseEntity<Model> getModelInfo(String id) {
-    if (Strings.isNullOrEmpty(id)) {
-      log.info("Request is missing a valid id");
-      return ResponseEntity.badRequest().build();
-    }
-    if (!id.equals(scorer.getModelId())) {
-      log.info("Model {} not found", id);
-      return ResponseEntity.notFound().build();
-    }
+  public ResponseEntity<Model> getModelInfo() {
     return ResponseEntity.ok(scorer.getModelInfo());
   }
 
   @Override
-  public ResponseEntity<List<String>> getModels() {
-    return ResponseEntity.ok(singletonList(scorer.getModelId()));
+  public ResponseEntity<String> getModelId() {
+    return ResponseEntity.ok(scorer.getModelId());
   }
 
   @Override
-  public ResponseEntity<ScoreResponse> getScore(ScoreRequest request, String id) {
-    if (Strings.isNullOrEmpty(id)) {
-      log.info("Request is missing a valid id");
-      return ResponseEntity.badRequest().build();
-    }
-    if (!id.equals(scorer.getModelId())) {
-      log.info("Model {} not found", id);
-      return ResponseEntity.notFound().build();
-    }
+  public ResponseEntity<ScoreResponse> getScore(ScoreRequest request) {
     try {
       return ResponseEntity.ok(scorer.score(request));
     } catch (Exception e) {
@@ -68,18 +49,10 @@ public class ModelsApiController implements ModelsApi {
   }
 
   @Override
-  public ResponseEntity<ScoreResponse> getScoreByFile(String id, String file) {
-    if (Strings.isNullOrEmpty(id)) {
-      log.info("Request is missing a valid id");
-      return ResponseEntity.badRequest().build();
-    }
+  public ResponseEntity<ScoreResponse> getScoreByFile(String file) {
     if (Strings.isNullOrEmpty(file)) {
       log.info("Request is missing a valid CSV file path");
       return ResponseEntity.badRequest().build();
-    }
-    if (!id.equals(scorer.getModelId())) {
-      log.info("Model {} not found", id);
-      return ResponseEntity.notFound().build();
     }
     try {
       return ResponseEntity.ok(scorer.scoreCsv(file));
@@ -95,11 +68,7 @@ public class ModelsApiController implements ModelsApi {
   }
 
   @Override
-  public ResponseEntity<ScoreRequest> getSampleRequest(String id) {
-    if (!id.equals(scorer.getModelId())) {
-      log.info("Model {} not found", id);
-      return ResponseEntity.notFound().build();
-    }
+  public ResponseEntity<ScoreRequest> getSampleRequest() {
     return ResponseEntity.ok(sampleRequestBuilder.build(scorer.getPipeline().getInputMeta()));
   }
 }


### PR DESCRIPTION
Our deployment templates only support loading a single model and we don't plan to change that.
As a result, having the model id in the request path is only a nuisance that makes calling the score unnecessarily complicated.

This PR changes that so that before too many people start relying on the current convoluted request paths.

Bumps version to `1.0.0-SNAPSHOT` to make the incompatible API change more obvious.