### PR TITLE
Push docker images to hub.docker.com.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,14 +176,14 @@ pipeline {
             }
             steps {
                 script {
-                    def harborCredentials = usernamePassword(
+                    def dockerhubCredentials = usernamePassword(
                             credentialsId: "dockerhub",
                             passwordVariable: "DOCKERHUB_PASSWORD",
                             usernameVariable: "DOCKERHUB_USERNAME",
                     )
                     def gitCommitHash = env.GIT_COMMIT
                     def imageTags = "${VERSION},${gitCommitHash}"
-                    withCredentials([harborCredentials]) {
+                    withCredentials([dockerhubCredentials]) {
                         sh "./gradlew jib \
                             -Djib.to.auth.username=${DOCKERHUB_USERNAME} \
                             -Djib.to.auth.password=${DOCKERHUB_PASSWORD} \

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,3 +36,6 @@ checkStyleVersion = 8.21
 googleJavaFormatVersion = 1.7
 errorproneJavacVersion = 9+181-r4173-1
 errorproneVersion = 2.3.3
+
+# Docker settings
+dockerRepositoryPrefix = harbor.h2o.ai/opsh2oai/h2oai/

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -40,7 +40,7 @@ jib {
         image = 'openjdk:8-jre-alpine'
     }
     to {
-        image = 'harbor.h2o.ai/opsh2oai/h2oai/rest-scorer'
+        image = dockerRepositoryPrefix + 'rest-scorer'
         tags = [version]
     }
     container {


### PR DESCRIPTION
We only push to DockerHub on release branches or when explicitly requested by the `PUSH_DOCKER_IMAGES_TO_DOCKERHUB` pipeline parameter.

An example result is here:
https://hub.docker.com/r/h2oai/rest-scorer/tags