### PR TITLE
Only depend on the slf4j api in the shared code.

### DIFF
--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
     implementation group: 'com.google.guava', name: 'guava'
-    implementation group: 'org.slf4j', name: 'slf4j-log4j12'
+    implementation group: 'org.slf4j', name: 'slf4j-api'
 
     testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
     testImplementation group: 'org.mockito', name: 'mockito-core'

--- a/gradle/mixins/dependencies.gradle
+++ b/gradle/mixins/dependencies.gradle
@@ -31,6 +31,9 @@ dependencyManagement {
             entry 'mockito-junit-jupiter'
         }
         dependency group: 'commons-cli', name: 'commons-cli', version: apacheCommonsCliVersion
-        dependency group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
+        dependencySet(group: 'org.slf4j', version: slf4jVersion) {
+            entry 'slf4j-api'
+            entry 'slf4j-log4j12'
+        }
     }
 }


### PR DESCRIPTION
This is to leave the actually logging back-end choice on the leaf binary package.