### PR TITLE
Return field names in the scoring response by default.

### DIFF
--- a/aws-lambda-scorer/README.md
+++ b/aws-lambda-scorer/README.md
@@ -111,60 +111,6 @@ The expected response should follow this structure, but the actual values may di
 ```json
 {
   "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
-  "score": [
-    [
-      "1.0",
-      "0.6240277982943945",
-      "0.045458571508101536",
-      "0.330513630197504"
-    ],
-    [
-      "3.0",
-      "0.7209441819603676",
-      "0.06299909138586585",
-      "0.21605672665376663"
-    ],
-    [
-      "4.0",
-      "0.7209441819603676",
-      "0.06299909138586585",
-      "0.21605672665376663"
-    ]
-  ]
-}
-```
-
-To get back also the names of fields in the order in which they appear in the resulting `score`,
-pass in an extra request field `includeFieldNames` set to `true`.
-
-```json
-{
-  "fields": [
-    "sepal_len", "sepal_wid", "petal_len", "petal_wid"
-  ],
-  "includeFieldsInOutput": [
-    "sepal_len"
-  ],
-  "includeFieldNames": true,
-  "rows": [
-    [
-      "1.0", "1.0", "2.2", "3.5"
-    ],
-    [
-      "3.0", "10.0", "2.2", "3.5"
-    ],
-    [
-      "4.0", "100.0", "2.2", "3.5"
-    ]
-  ]
-}
-```
-
-Resulting in a more verbose answer good for manual queries and debugging:
-
-```json
-{
-  "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
   "fields": [
     "sepal_len",
     "class.Iris-setosa",
@@ -193,3 +139,6 @@ Resulting in a more verbose answer good for manual queries and debugging:
   ]
 }
 ```
+
+Note that including the `fields` in the response can be disabled by setting `noFieldNames` to true
+in the input request.

--- a/aws-lambda-scorer/README.md
+++ b/aws-lambda-scorer/README.md
@@ -110,6 +110,67 @@ The expected response should follow this structure, but the actual values may di
 
 ```json
 {
+  "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
+  "score": [
+    [
+      "1.0",
+      "0.6240277982943945",
+      "0.045458571508101536",
+      "0.330513630197504"
+    ],
+    [
+      "3.0",
+      "0.7209441819603676",
+      "0.06299909138586585",
+      "0.21605672665376663"
+    ],
+    [
+      "4.0",
+      "0.7209441819603676",
+      "0.06299909138586585",
+      "0.21605672665376663"
+    ]
+  ]
+}
+```
+
+To get back also the names of fields in the order in which they appear in the resulting `score`,
+pass in an extra request field `includeFieldNames` set to `true`.
+
+```json
+{
+  "fields": [
+    "sepal_len", "sepal_wid", "petal_len", "petal_wid"
+  ],
+  "includeFieldsInOutput": [
+    "sepal_len"
+  ],
+  "includeFieldNames": true,
+  "rows": [
+    [
+      "1.0", "1.0", "2.2", "3.5"
+    ],
+    [
+      "3.0", "10.0", "2.2", "3.5"
+    ],
+    [
+      "4.0", "100.0", "2.2", "3.5"
+    ]
+  ]
+}
+```
+
+Resulting in a more verbose answer good for manual queries and debugging:
+
+```json
+{
+  "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
+  "fields": [
+    "sepal_len",
+    "class.Iris-setosa",
+    "class.Iris-versicolor",
+    "class.Iris-virginica"
+  ],
   "score": [
     [
       "1.0",

--- a/aws-lambda-scorer/README.md
+++ b/aws-lambda-scorer/README.md
@@ -140,5 +140,5 @@ The expected response should follow this structure, but the actual values may di
 }
 ```
 
-Note that including the `fields` in the response can be disabled by setting `noFieldNames` to true
-in the input request.
+Note that including the `fields` in the response can be disabled by setting `noFieldNamesInOutput`
+to true in the input request.

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -154,6 +154,12 @@ definitions:
         type: array
         items:
           type: string
+      includeFields:
+        description: >
+          If set to `true`. The scorer will also fill column names in `fields` field of its response.
+          This is mostly useful for human processing and debugging to facilitate matching response data to the
+          actual columns.
+        type: boolean
       idField:
         description: >
           Name of the field that holds a row id, e.g., a value that uniquely identifies each row of the request.
@@ -181,6 +187,13 @@ definitions:
         description: >
           A unique id of the model used for scoring.
         type: string
+      fields:
+        description: >
+          An array holding the names of fields in the order of appearance in the rows of the  `score` property.
+          This field is only populated if requested by the `includeFields` request field.
+        type: array
+        items:
+          type: string
       score:
         description: >
           An array of rows consisting the actual scoring output. The order of rows corresponds to the order of the input

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -154,7 +154,7 @@ definitions:
         type: array
         items:
           type: string
-      includeFields:
+      includeFieldNames:
         description: >
           If set to `true`. The scorer will also fill column names in `fields` field of its response.
           This is mostly useful for human processing and debugging to facilitate matching response data to the
@@ -190,7 +190,7 @@ definitions:
       fields:
         description: >
           An array holding the names of fields in the order of appearance in the rows of the  `score` property.
-          This field is only populated if requested by the `includeFields` request field.
+          This field is only populated if requested by the `includeFieldNames` request field.
         type: array
         items:
           type: string

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -154,11 +154,10 @@ definitions:
         type: array
         items:
           type: string
-      includeFieldNames:
+      noFieldNames:
         description: >
-          If set to `true`. The scorer will also fill column names in `fields` field of its response.
-          This is mostly useful for human processing and debugging to facilitate matching response data to the
-          actual columns.
+          If set to `true`. The scorer will not fill response column names in the `fields` field.
+          This is can be useful to maintain compatibility with older scorer versions or to save bandwidth.
         type: boolean
       idField:
         description: >
@@ -190,7 +189,7 @@ definitions:
       fields:
         description: >
           An array holding the names of fields in the order of appearance in the rows of the  `score` property.
-          This field is only populated if requested by the `includeFieldNames` request field.
+          This field is not populated if requested by setting the `noFieldNames` request field to `true`.
         type: array
         items:
           type: string

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -154,7 +154,7 @@ definitions:
         type: array
         items:
           type: string
-      noFieldNames:
+      noFieldNamesInOutput:
         description: >
           If set to `true`. The scorer will not fill response column names in the `fields` field.
           This is can be useful to maintain compatibility with older scorer versions or to save bandwidth.
@@ -189,7 +189,7 @@ definitions:
       fields:
         description: >
           An array holding the names of fields in the order of appearance in the rows of the  `score` property.
-          This field is not populated if requested by setting the `noFieldNames` request field to `true`.
+          This field is not populated if requested by setting the `noFieldNamesInOutput` request field to `true`.
         type: array
         items:
           type: string

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
@@ -37,7 +37,7 @@ public class MojoFrameToResponseConverter
     ScoreResponse response = new ScoreResponse();
     response.setScore(outputRows);
 
-    if (Optional.ofNullable(scoreRequest.isIncludeFieldNames()).orElse(Boolean.FALSE)) {
+    if (!Boolean.TRUE.equals(scoreRequest.isNoFieldNames())) {
       List<String> outputFieldNames = getFilteredInputFieldNames(scoreRequest, includedFields);
       outputFieldNames.addAll(asList(mojoFrame.getColumnNames()));
       response.setFields(outputFieldNames);

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
@@ -37,7 +37,7 @@ public class MojoFrameToResponseConverter
     ScoreResponse response = new ScoreResponse();
     response.setScore(outputRows);
 
-    if (!Boolean.TRUE.equals(scoreRequest.isNoFieldNames())) {
+    if (!Boolean.TRUE.equals(scoreRequest.isNoFieldNamesInOutput())) {
       List<String> outputFieldNames = getFilteredInputFieldNames(scoreRequest, includedFields);
       outputFieldNames.addAll(asList(mojoFrame.getColumnNames()));
       response.setFields(outputFieldNames);

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
@@ -37,7 +37,7 @@ public class MojoFrameToResponseConverter
     ScoreResponse response = new ScoreResponse();
     response.setScore(outputRows);
 
-    if (Optional.ofNullable(scoreRequest.isIncludeFields()).orElse(Boolean.FALSE)) {
+    if (Optional.ofNullable(scoreRequest.isIncludeFieldNames()).orElse(Boolean.FALSE)) {
       List<String> outputFieldNames = getFilteredInputFieldNames(scoreRequest, includedFields);
       outputFieldNames.addAll(asList(mojoFrame.getColumnNames()));
       response.setFields(outputFieldNames);

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
@@ -54,7 +54,7 @@ class MojoFrameToResponseConverterTest {
     Type[] types = {Type.Str};
     String[][] values = {{"value"}};
     ScoreRequest scoreRequest = new ScoreRequest();
-    scoreRequest.setIncludeFields(true);
+    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -74,7 +74,7 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.addFieldsItem("inputField");
     scoreRequest.addIncludeFieldsInOutputItem("inputField");
     scoreRequest.addRowsItem(asRow("inputValue"));
-    scoreRequest.setIncludeFields(true);
+    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -94,7 +94,7 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.setFields(asList("inputField1", "inputField2", "inputField3"));
     scoreRequest.setIncludeFieldsInOutput(asList("inputField1", "inputField3"));
     scoreRequest.addRowsItem(asRow("inputValue1", "omittedValue", "inputValue3"));
-    scoreRequest.setIncludeFields(true);
+    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -118,7 +118,7 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.setIncludeFieldsInOutput(asList("inputField", "id"));
     scoreRequest.addRowsItem(asRow("inputValue", "omittedValue", "testId"));
     scoreRequest.setIdField("id");
-    scoreRequest.setIncludeFields(true);
+    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -139,7 +139,7 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.setIncludeFieldsInOutput(asList("inputField", "id"));
     scoreRequest.addRowsItem(asRow("inputValue", "omittedValue", "testId"));
     scoreRequest.setIdField("id");
-    scoreRequest.setIncludeFields(true);
+    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -162,7 +162,7 @@ class MojoFrameToResponseConverterTest {
     Type[] types = {Type.Str};
     String[][] values = {{"value1"}, {"value2"}, {"value3"}};
     ScoreRequest scoreRequest = new ScoreRequest();
-    scoreRequest.setIncludeFields(true);
+    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -180,7 +180,7 @@ class MojoFrameToResponseConverterTest {
     Type[] types = {Type.Str, Type.Float32, Type.Float64, Type.Bool, Type.Int32, Type.Int64};
     String[][] values = {{"str", "1.1", "2.2", "1", "123", "123456789"}};
     ScoreRequest scoreRequest = new ScoreRequest();
-    scoreRequest.setIncludeFields(true);
+    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result =

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
@@ -28,7 +28,7 @@ class MojoFrameToResponseConverterTest {
 
     // Then
     assertThat(result.getScore()).isEmpty();
-    assertThat(result.getFields()).isNull();
+    assertThat(result.getFields()).isEmpty();
   }
 
   @Test
@@ -44,24 +44,24 @@ class MojoFrameToResponseConverterTest {
 
     // Then
     assertThat(result.getScore()).containsExactly(asRow("value"));
-    assertThat(result.getFields()).isNull();
+    assertThat(result.getFields()).containsExactly("field");
   }
 
   @Test
-  void convertSingleFieldResponse_withFields_succeeds() {
+  void convertSingleFieldResponse_withoutFieldNames_succeeds() {
     // Given
     String[] fields = {"field"};
     Type[] types = {Type.Str};
     String[][] values = {{"value"}};
     ScoreRequest scoreRequest = new ScoreRequest();
-    scoreRequest.setIncludeFieldNames(true);
+    scoreRequest.setNoFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
 
     // Then
     assertThat(result.getScore()).containsExactly(asRow("value"));
-    assertThat(result.getFields()).containsExactly("field");
+    assertThat(result.getFields()).isNull();
   }
 
   @Test
@@ -74,7 +74,6 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.addFieldsItem("inputField");
     scoreRequest.addIncludeFieldsInOutputItem("inputField");
     scoreRequest.addRowsItem(asRow("inputValue"));
-    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -94,7 +93,6 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.setFields(asList("inputField1", "inputField2", "inputField3"));
     scoreRequest.setIncludeFieldsInOutput(asList("inputField1", "inputField3"));
     scoreRequest.addRowsItem(asRow("inputValue1", "omittedValue", "inputValue3"));
-    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -118,7 +116,6 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.setIncludeFieldsInOutput(asList("inputField", "id"));
     scoreRequest.addRowsItem(asRow("inputValue", "omittedValue", "testId"));
     scoreRequest.setIdField("id");
-    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -139,7 +136,6 @@ class MojoFrameToResponseConverterTest {
     scoreRequest.setIncludeFieldsInOutput(asList("inputField", "id"));
     scoreRequest.addRowsItem(asRow("inputValue", "omittedValue", "testId"));
     scoreRequest.setIdField("id");
-    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -162,7 +158,6 @@ class MojoFrameToResponseConverterTest {
     Type[] types = {Type.Str};
     String[][] values = {{"value1"}, {"value2"}, {"value3"}};
     ScoreRequest scoreRequest = new ScoreRequest();
-    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);
@@ -180,7 +175,6 @@ class MojoFrameToResponseConverterTest {
     Type[] types = {Type.Str, Type.Float32, Type.Float64, Type.Bool, Type.Int32, Type.Int64};
     String[][] values = {{"str", "1.1", "2.2", "1", "123", "123456789"}};
     ScoreRequest scoreRequest = new ScoreRequest();
-    scoreRequest.setIncludeFieldNames(true);
 
     // When
     ScoreResponse result =

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverterTest.java
@@ -54,7 +54,7 @@ class MojoFrameToResponseConverterTest {
     Type[] types = {Type.Str};
     String[][] values = {{"value"}};
     ScoreRequest scoreRequest = new ScoreRequest();
-    scoreRequest.setNoFieldNames(true);
+    scoreRequest.setNoFieldNamesInOutput(true);
 
     // When
     ScoreResponse result = converter.apply(buildMojoFrame(fields, types, values), scoreRequest);

--- a/local-rest-scorer/README.md
+++ b/local-rest-scorer/README.md
@@ -89,8 +89,8 @@ The expected response should follow this structure, but the actual values may di
 }
 ```
 
-Note that including the `fields` in the response can be disabled by setting `noFieldNames` to true
-in the input request.
+Note that including the `fields` in the response can be disabled by setting `noFieldNamesInOutput`
+to true in the input request.
 
 ### Score CSV File
 

--- a/local-rest-scorer/README.md
+++ b/local-rest-scorer/README.md
@@ -59,6 +59,67 @@ The expected response should follow this structure, but the actual values may di
 
 ```json
 {
+  "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
+  "score": [
+    [
+      "1.0",
+      "0.6240277982943945",
+      "0.045458571508101536",
+      "0.330513630197504"
+    ],
+    [
+      "3.0",
+      "0.7209441819603676",
+      "0.06299909138586585",
+      "0.21605672665376663"
+    ],
+    [
+      "4.0",
+      "0.7209441819603676",
+      "0.06299909138586585",
+      "0.21605672665376663"
+    ]
+  ]
+}
+```
+
+To get back also the names of fields in the order in which they appear in the resulting `score`,
+pass in an extra request field `includeFieldNames` set to `true`.
+
+```json
+{
+  "fields": [
+    "sepal_len", "sepal_wid", "petal_len", "petal_wid"
+  ],
+  "includeFieldsInOutput": [
+    "sepal_len"
+  ],
+  "includeFieldNames": true,
+  "rows": [
+    [
+      "1.0", "1.0", "2.2", "3.5"
+    ],
+    [
+      "3.0", "10.0", "2.2", "3.5"
+    ],
+    [
+      "4.0", "100.0", "2.2", "3.5"
+    ]
+  ]
+}
+```
+
+Resulting in a more verbose answer good for manual queries and debugging:
+
+```json
+{
+  "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
+  "fields": [
+    "sepal_len",
+    "class.Iris-setosa",
+    "class.Iris-versicolor",
+    "class.Iris-virginica"
+  ],
   "score": [
     [
       "1.0",

--- a/local-rest-scorer/README.md
+++ b/local-rest-scorer/README.md
@@ -60,60 +60,6 @@ The expected response should follow this structure, but the actual values may di
 ```json
 {
   "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
-  "score": [
-    [
-      "1.0",
-      "0.6240277982943945",
-      "0.045458571508101536",
-      "0.330513630197504"
-    ],
-    [
-      "3.0",
-      "0.7209441819603676",
-      "0.06299909138586585",
-      "0.21605672665376663"
-    ],
-    [
-      "4.0",
-      "0.7209441819603676",
-      "0.06299909138586585",
-      "0.21605672665376663"
-    ]
-  ]
-}
-```
-
-To get back also the names of fields in the order in which they appear in the resulting `score`,
-pass in an extra request field `includeFieldNames` set to `true`.
-
-```json
-{
-  "fields": [
-    "sepal_len", "sepal_wid", "petal_len", "petal_wid"
-  ],
-  "includeFieldsInOutput": [
-    "sepal_len"
-  ],
-  "includeFieldNames": true,
-  "rows": [
-    [
-      "1.0", "1.0", "2.2", "3.5"
-    ],
-    [
-      "3.0", "10.0", "2.2", "3.5"
-    ],
-    [
-      "4.0", "100.0", "2.2", "3.5"
-    ]
-  ]
-}
-```
-
-Resulting in a more verbose answer good for manual queries and debugging:
-
-```json
-{
-  "id": "a12e7390-b8ac-406a-ade9-0d5ea4b63ea9",
   "fields": [
     "sepal_len",
     "class.Iris-setosa",
@@ -142,6 +88,9 @@ Resulting in a more verbose answer good for manual queries and debugging:
   ]
 }
 ```
+
+Note that including the `fields` in the response can be disabled by setting `noFieldNames` to true
+in the input request.
 
 ### Score CSV File
 

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/JsonConfiguration.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/JsonConfiguration.java
@@ -1,0 +1,17 @@
+package ai.h2o.mojos.deploy.local.rest.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class JsonConfiguration {
+
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    return mapper;
+  }
+}

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
@@ -6,8 +6,6 @@ import ai.h2o.mojos.deploy.common.transform.MojoPipelineToModelInfoConverter;
 import ai.h2o.mojos.deploy.common.transform.MojoScorer;
 import ai.h2o.mojos.deploy.common.transform.RequestToMojoFrameConverter;
 import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/config/ScorerConfiguration.java
@@ -6,6 +6,8 @@ import ai.h2o.mojos.deploy.common.transform.MojoPipelineToModelInfoConverter;
 import ai.h2o.mojos.deploy.common.transform.MojoScorer;
 import ai.h2o.mojos.deploy.common.transform.RequestToMojoFrameConverter;
 import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 


### PR DESCRIPTION
This can be disabled by passing in `"noFieldNames": true` in the scoring request and works both for AWS lambda and local rest scorer.

This is a relatively safe option as it adds a new field that can be easily ignored by existing clients. There is still a small chance of breaking an existing client who might have strict JSON parsing enabled. E.g., for Java using `FAIL_ON_UNKNOWN_PROPERTIES` (https://fasterxml.github.io/jackson-databind/javadoc/2.6/com/fasterxml/jackson/databind/DeserializationFeature.html#FAIL_ON_UNKNOWN_PROPERTIES)

**Q:** Why not build flag or java property?
**A:** These would apply globally for all requests. I think it is better when we give users the option to switch between more and less verbose on the fly as needed. This allows low-bandwidth when working with production queries as well as human debugging, when needed, without restarting the scorer.