### PR TITLE
Enable building war archive.

### DIFF
--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.google.cloud.tools.jib'
     id 'org.springframework.boot'
+    id 'war'
 }
 apply from: project(":").file('gradle/java.gradle')
 

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/ServletInitializer.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/ServletInitializer.java
@@ -1,0 +1,12 @@
+package ai.h2o.mojos.deploy.local.rest;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+public class ServletInitializer extends SpringBootServletInitializer {
+
+  @Override
+  protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+    return application.sources(ScorerApplication.class);
+  }
+}


### PR DESCRIPTION
More details:

To build the `*.war` file run `./gradlew build`. The resulting .war  file is here: `./local-rest-scorer/build/libs/local-rest-scorer-1.0.7-SNAPSHOT.war`.

I tested it by running a Tomcat docker image as follows:
```bash
docker run --rm --name tomcat -p 8082:8080 -e JAVA_OPTS="-Dmojo.path=/usr/local/tomcat/pipeline.mojo -Dai.h2o.mojos.runtime.license.key='$(cat ~/.driverlessai/license.sig)'" -v "${PWD}/local-rest-scorer/build/libs":/usr/local/tomcat/webapps -v "${HOME}/Downloads/pipeline.mojo":/usr/local/tomcat/pipeline.mojo  tomcat:9.0
```
Note that you would have to change the `pipeline.mojo` path.

This exposes the scorer on this path: http://localhost:8082/local-rest-scorer-1.0.7-SNAPSHOT/model/id

If the endpoint shows a model UUID, it works :slightly_smiling_face:. I only changed the port to 8082 (by -p 8082:8080) in order to prevent collision with anything already running there locally. Not strictly needed.