### PR TITLE
Include proper dependencies for the LRS to score H2O-3 models.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ version = 1.0.10-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
+h2oVersion = 3.28.1.2
 mojoRuntimeVersion = 2.3.1
 
 # External dependencies:

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.0.10-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
-mojoRuntimeVersion = 2.2.0
+mojoRuntimeVersion = 2.3.1
 
 # External dependencies:
 awsLambdaCoreVersion = 1.2.0

--- a/gradle/mixins/dependencies.gradle
+++ b/gradle/mixins/dependencies.gradle
@@ -6,6 +6,7 @@ dependencyManagement {
     dependencies {
         dependencySet(group: 'ai.h2o', version: mojoRuntimeVersion) {
             entry 'mojo2-runtime-api'
+            entry 'mojo2-runtime-h2o3-impl'
             entry 'mojo2-runtime-impl'
         }
         dependency group: 'com.amazonaws', name: 'aws-lambda-java-core', version: awsLambdaCoreVersion

--- a/gradle/mixins/dependencies.gradle
+++ b/gradle/mixins/dependencies.gradle
@@ -9,6 +9,10 @@ dependencyManagement {
             entry 'mojo2-runtime-h2o3-impl'
             entry 'mojo2-runtime-impl'
         }
+        dependencySet(group: 'ai.h2o', version: h2oVersion) {
+            entry 'h2o-genmodel'
+            entry 'h2o-genmodel-ext-xgboost'
+        }
         dependency group: 'com.amazonaws', name: 'aws-lambda-java-core', version: awsLambdaCoreVersion
         dependency group: 'com.amazonaws', name: 'aws-lambda-java-events', version: awsLambdaEventsVersion
         dependency group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: awsSdkS3Version

--- a/gradle/mixins/dependencies.gradle
+++ b/gradle/mixins/dependencies.gradle
@@ -4,14 +4,14 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     dependencies {
+        dependencySet(group: 'ai.h2o', version: h2oVersion) {
+            entry 'h2o-genmodel'
+            entry 'h2o-genmodel-ext-xgboost'
+        }
         dependencySet(group: 'ai.h2o', version: mojoRuntimeVersion) {
             entry 'mojo2-runtime-api'
             entry 'mojo2-runtime-h2o3-impl'
             entry 'mojo2-runtime-impl'
-        }
-        dependencySet(group: 'ai.h2o', version: h2oVersion) {
-            entry 'h2o-genmodel'
-            entry 'h2o-genmodel-ext-xgboost'
         }
         dependency group: 'com.amazonaws', name: 'aws-lambda-java-core', version: awsLambdaCoreVersion
         dependency group: 'com.amazonaws', name: 'aws-lambda-java-events', version: awsLambdaEventsVersion

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -7,6 +7,8 @@ apply from: project(":").file('gradle/java.gradle')
 dependencies {
     implementation project(':common:rest-spring-api')
     implementation project(':common:transform')
+    implementation group: 'ai.h2o', name: 'h2o-genmodel'
+    implementation group: 'ai.h2o', name: 'h2o-genmodel-ext-xgboost'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-h2o3-impl'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(':common:rest-spring-api')
     implementation project(':common:transform')
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
+    implementation group: 'ai.h2o', name: 'mojo2-runtime-h2o3-impl'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
     implementation group: 'io.springfox', name: 'springfox-swagger2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui'


### PR DESCRIPTION
Adds/updates the dependencies for the Local Rest Scorer to score H2O-3 models.

**Additionally:**
- Filed #161 as related and as a possible blocker for clients leveraging the Local Rest Scorer for H2O-3 models.
- I will publish a new release once I complete the task above.
