### PR TITLE
Remove useless override of one variant of method DummyPipeline.transform()

### DIFF
--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverterTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/MojoPipelineToModelInfoConverterTest.java
@@ -162,11 +162,6 @@ class MojoPipelineToModelInfoConverterTest {
     }
 
     @Override
-    public MojoFrame transform(MojoFrame inputFrame) {
-      throw new AssertionError("Not supported by test DummyPipeline.");
-    }
-
-    @Override
     public MojoFrame transform(MojoFrame inputFrame, MojoFrame outputFrame) {
       throw new AssertionError("Not supported by test DummyPipeline.");
     }


### PR DESCRIPTION
... to prevent compatibility issues with planned changes in mojo2's MojoPipeline.

Tiny change. The overriden method which this PR removes has no functional impact (it's a `transform()`method that, in derived implementation, calls another variant of `transform()`). So it was always useless; however, now it might hurt, because this use prevents changing that method to final (only one single variant of transform will be overridable in future).
