### PR TITLE
[MOJO] Update H2O-3 runtime to version 3.30.1.3.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.0.24-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
-h2oVersion = 3.28.1.2
+h2oVersion = 3.30.1.3
 mojoRuntimeVersion = 2.5.2
 
 # External dependencies:

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.0.24-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
-h2oVersion = 3.30.1.3
+h2oVersion = 3.30.1.2
 mojoRuntimeVersion = 2.5.2
 
 # External dependencies:


### PR DESCRIPTION
This updates H2O-3 runtime from `3.28.1.2` -> `3.30.1.3` (latest, at the time of writing) in order to support new H2O-3 MOJO versions (i.e. MOJO model version 1.40).

Doctor @mmalohlava: Mind if I open build/dev PRs to get a new release out?

> Edit: Modified target version to `3.30.1.2` as recommended.