### PR TITLE
[DEPS] Upgrade spring boot plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,15 @@ buildscript {
                 version: springBootPluginVersion
         classpath group: 'gradle.plugin.org.hidetake', name: 'gradle-swagger-generator-plugin',
                 version: swaggerGradlePluginVersion
-        classpath group: 'com.github.jengelman.gradle.plugins', name: 'shadow', version: shadowJarVersion
+        classpath group: 'com.github.jengelman.gradle.plugins', name: 'shadow',
+                version: shadowJarVersion
 //        classpath group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: spotlessPluginVersion
-        classpath group: 'net.ltgt.gradle', name: 'gradle-errorprone-plugin', version: errorpronePluginVersion
+        classpath group: 'net.ltgt.gradle', name: 'gradle-errorprone-plugin',
+                version: errorpronePluginVersion
         classpath group: 'com.google.cloud.tools.jib', name: 'com.google.cloud.tools.jib.gradle.plugin',
                 version: jibPluginVersion
-        classpath group: 'org.github.ngbinh.scalastyle', name: 'gradle-scalastyle-plugin_2.11', version: '1.0.1'
+        classpath group: 'org.github.ngbinh.scalastyle', name: 'gradle-scalastyle-plugin_2.11',
+                version: '1.0.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ sparklingWaterVersion = 3.28.0.1-1-2.4
 configVersion = 1.3.4
 
 # External plugins:
-springBootPluginVersion = 2.3.0.RELEASE
+springBootPluginVersion = 2.4.2
 swaggerGradlePluginVersion = 2.15.1
 spotlessPluginVersion = 3.24.2
 errorpronePluginVersion = 0.8.1


### PR DESCRIPTION
Before change
```
❯ gw --console=plain :local-rest-scorer:dependencyInsight --dependency org.apache.tomcat.embed:tomcat-embed-core:9.0.35
Found gradlew in /Users/michal/Devel/projects/h2o/repos/dai-deployment-templates

> Configure project :
1.0.29-SNAPSHOT

> Task :local-rest-scorer:dependencyInsight
org.apache.tomcat.embed:tomcat-embed-core:9.0.35 (selected by rule)
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes)
      org.gradle.category            = library (not requested)

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]

org.apache.tomcat.embed:tomcat-embed-core:9.0.35
+--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.35
|    \--- org.springframework.boot:spring-boot-starter-tomcat:2.3.0.RELEASE
|         \--- org.springframework.boot:spring-boot-starter-web:2.3.0.RELEASE
|              \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
\--- org.springframework.boot:spring-boot-starter-tomcat:2.3.0.RELEASE (*)

(*) - dependencies omitted (listed previously)
```

---

After change:
```
❯ gw --console=plain :local-rest-scorer:dependencyInsight --dependency org.apache.tomcat.embed:tomcat-embed-core:9.0.35
Found gradlew in /Users/michal/Devel/projects/h2o/repos/dai-deployment-templates

> Configure project :
1.0.29-SNAPSHOT

> Task :local-rest-scorer:dependencyInsight
No dependencies matching given input were found in configuration ':local-rest-scorer:compileClasspath'
```
