### PR TITLE
Update README.md

### DIFF
--- a/local-rest-scorer/README.md
+++ b/local-rest-scorer/README.md
@@ -18,6 +18,8 @@ To run the local scorer, you can either use `bootRun` gradle task or run directl
 java -Dmojo.path={PATH_TO_MOJO_PIPELINE} -jar build/libs/local-rest-scorer-{YOUR_CURRENT_VERSION}-boot.jar
 ``` 
 
+> Tip: If you run into an error loading the MOJO, ensure you specify its full path and are not triggering shell expansion (e.g. avoid the `~` character).
+
 ### Score JSON Request
 
 To test the endpoint, send a request to http://localhost:8080 as follows:


### PR DESCRIPTION
In cases where shell expansion is invoked during calls to the `local-rest-scorer`, users may receive a vague messages about not being able to load in a MOJO (`java.lang.RuntimeException: Could not load mojo
`).  Here's a quick README addition to try and curb people running into this issue.

The more permanent solution may be for the MOJO2 library to throw a more specific exception.

Update to the README inspired by @stexyz (thank you!).