### PR TITLE
Added shapley values to rest scorer endpoint

### DIFF
--- a/aws-sagemaker-hosted-scorer/src/main/java/ai/h2o/mojos/deploy/sagemaker/hosted/controller/ModelsApiController.java
+++ b/aws-sagemaker-hosted-scorer/src/main/java/ai/h2o/mojos/deploy/sagemaker/hosted/controller/ModelsApiController.java
@@ -53,7 +53,7 @@ public class ModelsApiController implements ModelApi {
 
   @Override
   @RequestMapping("/invocations")
-  public ResponseEntity<ScoreResponse> getScore(ScoreRequest request) {
+  public ResponseEntity<ScoreResponse> getScore(ScoreRequest request, Boolean shapleyResults) {
     try {
       log.info("Got scoring request");
       return ResponseEntity.ok(scorer.score(request));

--- a/common/swagger/swagger.yaml
+++ b/common/swagger/swagger.yaml
@@ -76,6 +76,11 @@ paths:
       produces:
         - application/json
       parameters:
+        - in: query
+          name: shapley_results
+          type: boolean
+          required: false
+          description: The boolean to say if Shap values are needed.
         - name: payload
           in: body
           required: true
@@ -203,6 +208,27 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Row'
+      input_shapley_contributions:
+        type: object
+        items:
+          $ref: '#/definitions/ShapleyResponse'
+  ShapleyResponse:
+    description: >
+      An Object that contains list of columns along with their shap values
+    type: object
+    properties:
+      fields:
+        description: >
+              An array holding the names of fields in the order of appearance in the rows of the  `contributions` property.
+        type: array
+        items:
+          type: string
+      contributions:
+        description: >
+              An array of rows consisting of the shapley contributions output corresponding to columns in the fields
+        type: array
+        items:
+              $ref: '#/definitions/Row'
   DataField:
     type: object
     properties:

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToResponseConverter.java
@@ -7,6 +7,7 @@ import static java.util.Collections.emptySet;
 import ai.h2o.mojos.deploy.common.rest.model.Row;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreResponse;
+import ai.h2o.mojos.deploy.common.rest.model.ShapleyResponse;
 import ai.h2o.mojos.runtime.frame.MojoFrame;
 import com.google.common.base.Strings;
 import java.util.ArrayList;
@@ -44,6 +45,24 @@ public class MojoFrameToResponseConverter
     }
 
     return response;
+  }
+
+  /**
+   * Converts the resulting shap values {@link MojoFrame} into the API response object {@link
+   * ShapleyResponse}.
+   */
+  public ShapleyResponse getShapleyResponse(MojoFrame shapleyMojoFrame) {
+    List<Row> outputRows = Stream.generate(Row::new).limit(shapleyMojoFrame.getNrows())
+            .collect(Collectors.toList());
+    copyResultFields(shapleyMojoFrame, outputRows);
+
+    ShapleyResponse contributions = new ShapleyResponse();
+    contributions.setContributions(outputRows);
+
+    List<String> outputFieldNames = new ArrayList<>(asList(shapleyMojoFrame.getColumnNames()));
+    contributions.setFields(outputFieldNames);
+
+    return contributions;
   }
 
   private static void copyFilteredInputFields(

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class ModelsApiController implements ModelApi {
@@ -48,10 +49,11 @@ public class ModelsApiController implements ModelApi {
   }
 
   @Override
-  public ResponseEntity<ScoreResponse> getScore(ScoreRequest request) {
+  public ResponseEntity<ScoreResponse> getScore(ScoreRequest request, Boolean shapleyResults) {
     try {
       log.info("Got scoring request");
-      return ResponseEntity.ok(scorer.score(request));
+      ScoreResponse scoreResponse = scorer.getScoreResponse(request, shapleyResults);
+      return ResponseEntity.ok(scoreResponse);
     } catch (Exception e) {
       log.info("Failed scoring request: {}, due to: {}", request, e.getMessage());
       log.debug(" - failure cause: ", e);


### PR DESCRIPTION
Aim: to provide Shapley values along with the /model/score endpoint optionally if requested by the client

The boolean is called shapley_results
(still on discussion here https://docs.google.com/document/d/1HWArQP7RTqJ7JHt2C_Tw8MAZkBCIfwCnLT9cR2kLdT8/edit#)
The boolean can take true or false.

When true - it provides Shapley values for transformed features
When false - it provides just the predictions

When the boolean is not specified the response contains just the predictions (for backward compatibility)

Sample request 

```
curl -X POST -H "Content-Type: application/json" -d @- http://localhost:8080/model/score?shapley_results=false << EOF
> {
> "fields": [
> "SEX",
> "EDUCATION",
> "MARRIAGE",
> "AGE",
> "PAY_0",
> "PAY_2",
> "PAY_3",
> "PAY_5",
> "PAY_6",
> "BILL_AMT1",
> "BILL_AMT2",
> "BILL_AMT3",
> "BILL_AMT4",
> "BILL_AMT5",
> "BILL_AMT6",
> "default payment next month"
> ],
> "rows": [
> [
> "200000",
> "5656540",
> "545645",
> "46560",
> "5646540",
> "65650",
> "8970",
> "650",
> "65450",
> "650",
> "323",
> "65654610",
> "54654560",
> "6540",
> "5654640",
> "45"
> ]
> ]
> }
> EOF
```

Sample response:
```
{
    "fields": [
        "DEFAULT_PAYMENT_NEXT_MONTH.0",
        "DEFAULT_PAYMENT_NEXT_MONTH.1"
    ],
    "id": "d4d9f3b2-6684-11eb-b26b-0242ac160002",
    "input_shapley_contributions": {
        "contributions": [
            [
                "0.08655235576142849",
                "0.17755834498323503",
                "0.11726781304049533",
                "0.05944305682214447",
                "0.18670045406517202",
                "0.19617270279719623",
                "0.0235254064670083",
                "0.011334227180886265",
                "0.1293810222042146",
                "0.01399531834032121",
                "0.4860454284545842",
                "-0.017030369151606387",
                "-0.03653463864110455",
                "0.02236090691885419",
                "0.07098252251027308",
                "0.062368919563852994",
                "-0.018671770872832012",
                "0.04777002737189121",
                "0.2882069919194666",
                "-0.11866462772248354",
                "-1.5065382607973277",
                "0.005561879751873049",
                "0.012783472437596623",
                "0.0019412590251431153",
                "-0.020104641954568125",
                "-0.0013931671882688665",
                "-0.007807095850078645",
                "-0.0019267584840470028",
                "-0.004633151264516323"
            ]
        ],
        "fields": [
            "contrib_0_AGE",
            "contrib_12_PAY_5",
            "contrib_14_PAY_AMT1",
            "contrib_15_PAY_AMT2",
            "contrib_16_PAY_AMT3",
            "contrib_17_PAY_AMT4",
            "contrib_18_PAY_AMT5",
            "contrib_19_PAY_AMT6",
            "contrib_1_BILL_AMT1",
            "contrib_28_CVTE:EDUCATION.0",
            "contrib_29_NumToCatTE:PAY_1:PAY_2:PAY_3:PAY_6.0",
            "contrib_2_BILL_AMT2",
            "contrib_34_NumToCatTE:PAY_1:PAY_2:PAY_AMT2.0",
            "contrib_35_NumToCatWoE:PAY_1:PAY_2:PAY_3.0",
            "contrib_36_PAY_6",
            "contrib_3_BILL_AMT3",
            "contrib_5_BILL_AMT5",
            "contrib_6_BILL_AMT6",
            "contrib_7_LIMIT_BAL",
            "contrib_8_PAY_1",
            "contrib_bias",
            "contrib_39_CVCatNumEnc:EDUCATION:MARRIAGE:PAY_3.max",
            "contrib_39_CVCatNumEnc:EDUCATION:MARRIAGE:PAY_AMT2.max",
            "contrib_39_CVCatNumEnc:EDUCATION:MARRIAGE:PAY_AMT4.max",
            "contrib_41_CVCatNumEnc:EDUCATION:MARRIAGE:SEX:PAY_1.count",
            "contrib_41_CVCatNumEnc:EDUCATION:MARRIAGE:SEX:PAY_2.count",
            "contrib_42_CVCatNumEnc:EDUCATION:AGE.mean",
            "contrib_42_CVCatNumEnc:EDUCATION:PAY_1.mean",
            "contrib_43_Freq:EDUCATION:MARRIAGE:SEX"
        ]
    },
    "score": [
        [
            "0.43373027989329327",
            "0.5662697201067067"
        ]
    ]
}
```
