### PR TITLE
Updates Lambda Deployment to have flexible memory requests

### DIFF
--- a/aws-lambda-scorer/README.md
+++ b/aws-lambda-scorer/README.md
@@ -54,6 +54,8 @@ environmental variables (using the prefix `TF_VAR_`):
 * `bucket_name`: Name of AWS S3 bucket to store the mojo to so that the lambda
   can access and load it. Note that the bucket has to already exist and
   the effective AWS account has to have write access to it.
+* (OPTIONAL) `lambda_memory_size`: amount of memory to allocate to the AWS lambda function.
+  Default is `3008`, Maximum is `10030`, `~3GB` and `~10GB` respectively. 
 
 Once all the non-optional variables are set, the following command will push
 the lambda (or update any changes thereof): `terraform apply`.
@@ -62,6 +64,18 @@ Upon successful push, Terraform will output the URL of the lambda endpoint and
 the corresponding `api_key`.
 Note that the recipe sets up AWS API Gateway proxy, see `api_gateway.tf`.
 Look for `base_url` and `api_key` in the output.
+
+#### Resource Considerations
+
+Mojo pipelines are loaded into memory when deployed. AWS Lambda supports deployments that can
+require up to 10GB of memory: https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html.
+
+As per AWS documentation, Lambda functions can support memory requests between 128 MB to 1024 MB (~10GB)
+
+By default, this template requests 3008 MB (~3GB) but this can be changed using terraform variable
+`lambda_memory_size`. 
+
+### Scoring
 
 ```text
 Outputs:

--- a/aws-lambda-scorer/terraform-recipe/main.tf
+++ b/aws-lambda-scorer/terraform-recipe/main.tf
@@ -15,6 +15,11 @@ variable "lambda_zip_path" {
   description = "Local path to the actual lambda scorer distribution."
   default = "../lambda-template/build/distributions/lambda-template.zip"
 }
+variable "lambda_memory_size" {
+  description = "Amount of memory requested for AWS Lambda function."
+  type = number
+  default = 3008
+}
 variable "license_key" {
   description = "Driverless AI license key."
 }
@@ -54,7 +59,7 @@ resource "aws_lambda_function" "scorer" {
 
   // Increase resource constraints from the defaults of 3s and 128MB.
   timeout = 900
-  memory_size = 3008
+  memory_size = ${var.lambda_memory_size}
 
   environment {
     variables = {

--- a/aws-lambda-scorer/terraform-recipe/main.tf
+++ b/aws-lambda-scorer/terraform-recipe/main.tf
@@ -59,7 +59,7 @@ resource "aws_lambda_function" "scorer" {
 
   // Increase resource constraints from the defaults of 3s and 128MB.
   timeout = 900
-  memory_size = ${var.lambda_memory_size}
+  memory_size = var.lambda_memory_size
 
   environment {
     variables = {


### PR DESCRIPTION
* adds information regarding memory requests to readme
* converts `memory_size` to terraform variable with default

This should be safe with DAI deployments given that the requested memory does not change for DAI, there is default that is the same as original request size. However, manual deployments can change this as now AWS supports 10GB memory functions