### PR TITLE
No type number for terraform 0.11

### DIFF
--- a/aws-lambda-scorer/terraform-recipe/main.tf
+++ b/aws-lambda-scorer/terraform-recipe/main.tf
@@ -17,7 +17,6 @@ variable "lambda_zip_path" {
 }
 variable "lambda_memory_size" {
   description = "Amount of memory requested for AWS Lambda function."
-  type = number
   default = 3008
 }
 variable "license_key" {
@@ -59,7 +58,7 @@ resource "aws_lambda_function" "scorer" {
 
   // Increase resource constraints from the defaults of 3s and 128MB.
   timeout = 900
-  memory_size = var.lambda_memory_size
+  memory_size = "${var.lambda_memory_size}"
 
   environment {
     variables = {


### PR DESCRIPTION
See https://www.terraform.io/docs/configuration-0-11/variables.html#type if left blank will be inferred from default.
If we decide to move beyond version 0.11, then we will need to decide what to do with old DAI terraform states (not guaranteed one can destroy old state using new tf version)