### PR TITLE
Mitigate CVE-2021-41079 by making tomcat-embed-core install explicit to version 9.0.54

### DIFF
--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation group: 'io.springfox', name: 'springfox-swagger2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'


### PR DESCRIPTION
Title self explanatory.