### PR TITLE
Adds support for configuring shapley value scoring via environment variable

### DIFF
--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
-    testImplementation group: 'uk.org.webcompere', name: 'system-stubs-jupiter', version: '1.2.0'
+    testImplementation group: 'uk.org.webcompere', name: 'system-stubs-jupiter'
 }
 
 test {

--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
+    testImplementation group: 'uk.org.webcompere', name: 'system-stubs-jupiter', version: '1.2.0'
 }
 
 test {

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoScorer.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoScorer.java
@@ -45,8 +45,6 @@ public class MojoScorer {
   private static final String MOJO_PIPELINE_PATH_PROPERTY = "mojo.path";
   private static final String MOJO_PIPELINE_PATH = System.getProperty(MOJO_PIPELINE_PATH_PROPERTY);
   private static final MojoPipeline pipeline = loadMojoPipelineFromFile();
-  private static final String SHAPLEY_ENABLE_PROPERTY = "shapley.enable";
-  private static final String SHAPLEY_ENABLED_TYPES_PROPERTY = "shapley.types.enabled";
 
   private final ShapleyLoadOption enabledShapleyTypes;
   private final boolean shapleyEnabled;
@@ -82,13 +80,8 @@ public class MojoScorer {
     this.modelInfoConverter = modelInfoConverter;
     this.csvConverter = csvConverter;
 
-    this.enabledShapleyTypes =
-        Boolean.getBoolean(SHAPLEY_ENABLE_PROPERTY)
-            ? ShapleyLoadOption.ALL
-            : ShapleyLoadOption.valueOf(
-            System.getProperty(SHAPLEY_ENABLED_TYPES_PROPERTY, "NONE"));
-    this.shapleyEnabled =
-        ShapleyLoadOption.isEnabled(enabledShapleyTypes);
+    this.enabledShapleyTypes = ShapleyLoadOption.fromEnvironment();
+    this.shapleyEnabled = ShapleyLoadOption.isEnabled(enabledShapleyTypes);
 
     loadMojoPipelinesForShapley();
   }

--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/ShapleyLoadOption.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/ShapleyLoadOption.java
@@ -9,6 +9,10 @@ public enum ShapleyLoadOption {
   ORIGINAL,
   TRANSFORMED;
 
+  private static final String SHAPLEY_ENABLE_PROPERTY = "shapley.enable";
+  private static final String SHAPLEY_ENABLE_ENV_VAR = "SHAPLEY_ENABLE";
+  private static final String SHAPLEY_ENABLED_TYPES_PROPERTY = "shapley.types.enabled";
+  private static final String SHAPLEY_ENABLED_TYPES_ENV_VAR = "SHAPLEY_TYPES_ENABLED";
 
   /**
    * Checks whether Shapley scoring is permitted.
@@ -37,5 +41,33 @@ public enum ShapleyLoadOption {
       return true;
     }
     return option.name().equals(requested);
+  }
+
+  /**
+   * Extracts configuration from system properties or environment variables.
+   * @return {@link ShapleyLoadOption}
+   */
+  public static ShapleyLoadOption fromEnvironment() {
+    return shapleyEnabledFromEnvironment()
+        ? ALL
+        : shapleyTypeFromEnvironment();
+  }
+
+  private static boolean shapleyEnabledFromEnvironment() {
+    boolean enabledProperty = Boolean.getBoolean(SHAPLEY_ENABLE_PROPERTY);
+    boolean enabledEnvironment = Boolean.parseBoolean(System.getenv(SHAPLEY_ENABLE_ENV_VAR));
+    return enabledEnvironment || enabledProperty;
+  }
+
+  private static ShapleyLoadOption shapleyTypeFromEnvironment() {
+    String enabledTypeProperty = System.getProperty(SHAPLEY_ENABLED_TYPES_PROPERTY);
+    if (enabledTypeProperty != null) {
+      return ShapleyLoadOption.valueOf(enabledTypeProperty);
+    }
+    String enabledTypeEnvironment = System.getenv(SHAPLEY_ENABLED_TYPES_ENV_VAR);
+    if (enabledTypeEnvironment != null) {
+      return ShapleyLoadOption.valueOf(enabledTypeEnvironment);
+    }
+    return NONE;
   }
 }

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/ShapleyLoadOptionTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/ShapleyLoadOptionTest.java
@@ -12,7 +12,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 @ExtendWith(SystemStubsExtension.class)
-public class ShapleyLoadOptionTest {
+class ShapleyLoadOptionTest {
 
   @SystemStub
   private EnvironmentVariables environmentVariables;

--- a/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/ShapleyLoadOptionTest.java
+++ b/common/transform/src/test/java/ai/h2o/mojos/deploy/common/transform/ShapleyLoadOptionTest.java
@@ -1,0 +1,143 @@
+package ai.h2o.mojos.deploy.common.transform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+@ExtendWith(SystemStubsExtension.class)
+public class ShapleyLoadOptionTest {
+
+  @SystemStub
+  private EnvironmentVariables environmentVariables;
+
+  @BeforeEach
+  void verifyEnvironment() {
+    assertNull(System.getenv("SHAPLEY_ENABLE"));
+    assertNull(System.getenv("SHAPLEY_TYPES_ENABLED"));
+    assertNull(System.getProperty("shapley.enable"));
+    assertNull(System.getProperty("shapley.types.enabled"));
+  }
+
+  @AfterEach
+  void clearProperties() {
+    System.clearProperty("shapley.enable");
+    System.clearProperty("shapley.types.enabled");
+
+    environmentVariables.set("SHAPLEY_ENABLE", null);
+    environmentVariables.set("SHAPLEY_TYPES_ENABLED", null);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_NoConfig_ReturnsDefault() {
+    // Given
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.NONE, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_EnabledEnvironmentVariable_ReturnsAll() {
+    // Given
+    environmentVariables.set("SHAPLEY_ENABLE", "true");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.ALL, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_EnabledSystemProperty_ReturnsAll() {
+    // Given
+    System.setProperty("shapley.enable", "true");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.ALL, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_TypeInEnvironmentAll_ReturnsAll() {
+    // Given
+    environmentVariables.set("SHAPLEY_TYPES_ENABLED", "ALL");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.ALL, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_TypeInEnvironmentTranformed_ReturnsTransformed() {
+    // Given
+    environmentVariables.set("SHAPLEY_TYPES_ENABLED", "TRANSFORMED");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.TRANSFORMED, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_TypeInEnvironmentOriginal_ReturnsOriginal() {
+    // Given
+    environmentVariables.set("SHAPLEY_TYPES_ENABLED", "ORIGINAL");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.ORIGINAL, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_TypeInPropertiesAll_ReturnsAll() {
+    // Given
+    System.setProperty("shapley.types.enabled", "ALL");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.ALL, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_TypeInPropertiesTransformed_ReturnsTransformed() {
+    // Given
+    System.setProperty("shapley.types.enabled", "TRANSFORMED");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.TRANSFORMED, option);
+  }
+
+  @Test
+  void loadOptionFromConfiguration_TypeInPropertiesOriginal_ReturnsOriginal() {
+    // Given
+    System.setProperty("shapley.types.enabled", "TRANSFORMED");
+
+    // When
+    ShapleyLoadOption option = ShapleyLoadOption.fromEnvironment();
+
+    // Then
+    assertEquals(ShapleyLoadOption.ORIGINAL, option);
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ awsSdkS3Version = 1.11.445
 javaxAnnotationVersion = 1.3.2
 gsonVersion = 2.8.5
 jupiterVersion = 5.3.1
+jupiterSystemStubsVersion = 1.2.0
 mockitoVersion = 3.0.0
 springFoxVersion = 3.0.0
 swaggerCodegenVersion = 3.0.0

--- a/gradle/mixins/dependencies.gradle
+++ b/gradle/mixins/dependencies.gradle
@@ -49,6 +49,7 @@ dependencyManagement {
         dependency group: 'org.scala-lang', name: 'scala-library', version: scalaVersion
         dependency group: 'ai.h2o', name: 'sparkling-water-scoring_2.11', version: sparklingWaterVersion
         dependency group: 'com.typesafe', name:'config', version: configVersion
+        dependency group: 'uk.org.webcompere', name: 'system-stubs-jupiter', version: jupiterSystemStubsVersion
 
     }
 }


### PR DESCRIPTION
as per comment here: https://github.com/h2oai/dai-deployment-templates/pull/270#discussion_r762343537

we need to support setting environment variables to configure shapley scoring for mlops purposes. 

TBH, I'd like to consider something like picocli to configure this moving forwards, but for now, this provides decent functionality as well as the ability for all our scorers here to implement shapley if necessary. 