### PR TITLE
Bump jib plugin version to 2.7.1

### DIFF
--- a/aws-sagemaker-hosted-scorer/build.gradle
+++ b/aws-sagemaker-hosted-scorer/build.gradle
@@ -44,8 +44,8 @@ jib {
         image = dockerRepositoryPrefix + 'sagemaker-hosted-scorer'
         tags = [version]
         auth {
-            username = System.getenv('TO_DOCKER_USERNAME')
-            password = System.getenv('TO_DOCKER_PASSWORD')
+            username = System.getenv('TO_DOCKER_USERNAME') ?: ''
+            password = System.getenv('TO_DOCKER_PASSWORD') ?: ''
         }
     }
     container {

--- a/gcp-cloud-run/build.gradle
+++ b/gcp-cloud-run/build.gradle
@@ -41,8 +41,8 @@ jib {
         image = dockerRepositoryPrefix + 'google-cloud-run-scorer'
         tags = [version]
         auth {
-            username = System.getenv('TO_DOCKER_USERNAME')
-            password = System.getenv('TO_DOCKER_PASSWORD')
+            username = System.getenv('TO_DOCKER_USERNAME') ?: ''
+            password = System.getenv('TO_DOCKER_PASSWORD') ?: ''
         }
     }
     container {

--- a/gcp-vertex-ai-mojo-scorer/build.gradle
+++ b/gcp-vertex-ai-mojo-scorer/build.gradle
@@ -58,8 +58,8 @@ jib {
         image = dockerRepositoryPrefix + 'google-vertex-ai-scorer'
         tags = [version]
         auth {
-            username = System.getenv('TO_DOCKER_USERNAME')
-            password = System.getenv('TO_DOCKER_PASSWORD')
+            username = System.getenv('TO_DOCKER_USERNAME') ?: ''
+            password = System.getenv('TO_DOCKER_PASSWORD') ?: ''
         }
     }
     container {

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ springBootPluginVersion = 2.5.8
 swaggerGradlePluginVersion = 2.15.1
 spotlessPluginVersion = 3.24.2
 errorpronePluginVersion = 0.8.1
-jibPluginVersion = 1.5.1
+jibPluginVersion = 2.7.1
 
 # External tools:
 checkStyleVersion = 8.21

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -61,8 +61,8 @@ jib {
         image = dockerRepositoryPrefix + 'rest-scorer'
         tags = [version]
         auth {
-            username = System.getenv('TO_DOCKER_USERNAME')
-            password = System.getenv('TO_DOCKER_PASSWORD')
+            username = System.getenv('TO_DOCKER_USERNAME') ?: ''
+            password = System.getenv('TO_DOCKER_PASSWORD') ?: ''
         }
     }
     container {


### PR DESCRIPTION
Bump jib plugin version so it is compatible with jackson 2.12.
Similar issue here: https://github.com/GoogleContainerTools/jib/issues/2931

Build error:
```
10:57:13  > com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException: Java 8 date/time type `java.time.Instant` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: java.util.ArrayList[0]->com.google.cloud.tools.jib.cache.LayerEntriesSelector$LayerEntryTemplate["sourceModificationTime"])
```

![image](https://user-images.githubusercontent.com/51244975/149555120-393f639f-f323-4433-912e-03d4041546b6.png)
