### PR TITLE
Bump `ai.h2o` dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.1.15-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
-h2oVersion = 3.32.0.2
+h2oVersion = 3.36.1.2
 mojoRuntimeVersion = 2.7.7
 
 # External dependencies:

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ version = 1.1.15-SNAPSHOT
 
 # Internal dependencies:
 h2oVersion = 3.36.1.2
-mojoRuntimeVersion = 2.7.7
+mojoRuntimeVersion = 2.7.8
 
 # External dependencies:
 awsLambdaCoreVersion = 1.2.0


### PR DESCRIPTION
**Changes:**
- Update `ai.h2o.h2o-genmodel` and `ai.h2o.h2o-genmodel-ext-xgboost` from `3.32.0.2` to `3.36.1.2`.
- Update `ai.h2o.mojo2` dependencies from `2.7.7` to `2.7.8`.
