### PR TITLE
Address CVE-2019-10086 by adding dependency constraint to the beanutils versions that mojo2-runtime-impl expects

### DIFF
--- a/aws-lambda-scorer/lambda-template/build.gradle
+++ b/aws-lambda-scorer/lambda-template/build.gradle
@@ -5,6 +5,10 @@ dependencies {
     implementation project(':common:transform')
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    constraints {
+        // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
+        compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    }
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-core'
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-events'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3'

--- a/aws-sagemaker-hosted-scorer/build.gradle
+++ b/aws-sagemaker-hosted-scorer/build.gradle
@@ -9,6 +9,10 @@ dependencies {
     implementation project(':common:transform')
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    constraints {
+        // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
+        compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    }
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: springFoxVersion
     implementation group: 'com.google.guava', name: 'guava', version: guavaVersion
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'

--- a/common/jdbc/build.gradle
+++ b/common/jdbc/build.gradle
@@ -9,6 +9,10 @@ dependencies {
     implementation project(':common:rest-jdbc-spring-api')
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    constraints {
+        // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
+        compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    }
     implementation group: 'ai.h2o', name: 'sparkling-water-scoring_2.12'
     implementation group: 'org.scala-lang', name: 'scala-library'
     implementation group: 'org.apache.spark', name: 'spark-core_2.12'

--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -4,6 +4,10 @@ dependencies {
     implementation project(':common:rest-java-model')
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    constraints {
+        // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
+        compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    }
     implementation group: 'com.google.guava', name: 'guava'
     implementation group: 'org.slf4j', name: 'slf4j-api'
 

--- a/gcp-vertex-ai-mojo-scorer/build.gradle
+++ b/gcp-vertex-ai-mojo-scorer/build.gradle
@@ -13,6 +13,10 @@ dependencies {
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-h2o3-impl'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    constraints {
+        // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
+        compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    }
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: springFoxVersion
     implementation group: 'com.google.guava', name: 'guava', version: guavaVersion
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'

--- a/kdb-mojo-scorer/build.gradle
+++ b/kdb-mojo-scorer/build.gradle
@@ -7,6 +7,10 @@ dependencies {
     implementation project(':common:kdb-java')
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    constraints {
+        // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
+        compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    }
     implementation group: 'commons-cli', name: 'commons-cli'
     implementation group: 'org.slf4j', name: 'slf4j-api'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api'

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -12,6 +12,10 @@ dependencies {
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-h2o3-impl'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    constraints {
+        // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
+        compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    }
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: springFoxVersion
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.60'


### PR DESCRIPTION
Mitigate CVE-2019-10086

(Mojo already uses the expected version at: https://github.com/h2oai/mojo2/pull/1209/files)