### PR TITLE
Bump tomcat embed core

### DIFF
--- a/aws-sagemaker-hosted-scorer/build.gradle
+++ b/aws-sagemaker-hosted-scorer/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: springFoxVersion
     implementation group: 'com.google.guava', name: 'guava', version: guavaVersion
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.60'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.60'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.63'
 }
 
 test {

--- a/gcp-cloud-run/build.gradle
+++ b/gcp-cloud-run/build.gradle
@@ -8,8 +8,8 @@ dependencies {
     implementation project(':local-rest-scorer')
     implementation group: 'org.slf4j', name: 'slf4j-api'
     implementation group: 'com.google.cloud', name: 'google-cloud-storage'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.60'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.60'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.63'
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ sparklingWaterVersion = 3.30.1.3-1-3.0
 configVersion = 1.3.4
 
 # External plugins:
-springBootPluginVersion = 2.6.6
+springBootPluginVersion = 2.6.8
 swaggerGradlePluginVersion = 2.15.1
 spotlessPluginVersion = 3.24.2
 errorpronePluginVersion = 0.8.1

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     }
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: springFoxVersion
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.60'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
 
     implementation group: 'com.google.guava', name: 'guava', version: guavaVersion
 


### PR DESCRIPTION
Mitigate: CVE-2022-29885

```
org.apache.tomcat.embed:tomcat-embed-core:9.0.63 (selected by rule)
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.version         = 8
   ]

org.apache.tomcat.embed:tomcat-embed-core:9.0.63
+--- compileClasspath
+--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.63
|    \--- org.springframework.boot:spring-boot-starter-tomcat:2.6.8
|         \--- org.springframework.boot:spring-boot-starter-web:2.6.8
|              \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
\--- org.springframework.boot:spring-boot-starter-tomcat:2.6.8 (*)

(*) - dependencies omitted (listed previously)

```