### PR TITLE
[qFIX][API] Change naming for media scoring parameter

### DIFF
--- a/common/swagger/v1exp/swagger.yaml
+++ b/common/swagger/v1exp/swagger.yaml
@@ -53,7 +53,7 @@ components:
       allOf:
         - $ref: '../v1/swagger.yaml#/definitions/ScoreRequest'
         - properties:
-            mediaColumns:
+            mediaFields:
               description: >
                 An array holding the names of all fields which are expected to contain media files.
                 Contents of these fields will be replaced by corresponding uploaded files where the


### PR DESCRIPTION
From online slack discussion. It makes more sense to have parameter name set as `mediaFields` as opposed to `mediaColumns` for consistency with the `fields` parameter that already exists. 
