### PR TITLE
Update Java base image from openjdk:17-alpine to eclipse-temurin:17.0.4.1_1-jdk-alpine.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,8 @@ errorproneVersion = 2.3.3
 # Docker settings
 dockerRepositoryPrefix = harbor.h2o.ai/opsh2oai/h2oai/
 dockerIncludePython = true
-javaBaseImage = openjdk:17-alpine
+# Digest of eclipse-temurin:17.0.4.1_1-jdk-alpine
+javaBaseImage = eclipse-temurin@sha256:06e31b7e02c379a8a8a91241497d2860859a42e10c72fe20b52fee8e67fd5df3
 
 # Increase timeouts to avoid read error from OSS Nexus
 # See:


### PR DESCRIPTION
The [OpenJDK image is deprecated](https://github.com/docker-library/openjdk/issues/505).  This commit replaces the OpenJDK image with Eclipse Temurin builds ([formerly AdoptOpenJDK](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/)).

Additionally, this commit specifies image digest so as to protect builds from image tag updates.