### PR TITLE
Update base JDK image and H2O.ai dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.1.18-SNAPSHOT
 # issue resolution.
 
 # Internal dependencies:
-h2oVersion = 3.36.1.2
+h2oVersion = 3.38.0.3
 mojoRuntimeVersion = 2.7.11.1
 
 # External dependencies:

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,8 +48,8 @@ errorproneVersion = 2.3.3
 # Docker settings
 dockerRepositoryPrefix = harbor.h2o.ai/opsh2oai/h2oai/
 dockerIncludePython = true
-# Digest of eclipse-temurin:17.0.4.1_1-jdk-alpine
-javaBaseImage = eclipse-temurin@sha256:06e31b7e02c379a8a8a91241497d2860859a42e10c72fe20b52fee8e67fd5df3
+# Digest of eclipse-temurin:17.0.5_8-jdk-alpine
+javaBaseImage = eclipse-temurin@sha256:1451b2df3a00e2ab14c4c63c6c9f8211c318f450954971bb8763bb100ce248c1
 
 # Increase timeouts to avoid read error from OSS Nexus
 # See:

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ version = 1.1.18-SNAPSHOT
 
 # Internal dependencies:
 h2oVersion = 3.36.1.2
-mojoRuntimeVersion = 2.7.9
+mojoRuntimeVersion = 2.7.11.1
 
 # External dependencies:
 awsLambdaCoreVersion = 1.2.0


### PR DESCRIPTION
Reduces vulnerabilities from `2` -> `0`, including `CVE-2022-40674` and `CVE-2022-43680`.

![image](https://user-images.githubusercontent.com/1426304/204437186-dc21804c-b352-42da-b960-6ec00c860b4e.png)

Additionally updates H2O dependencies.

Changes:
- Update base JDK image.
- Update ai.h2o.mojo2 dependencies to 2.7.11.1
- Update H2O-3 genmodel to 3.38.0.3