### PR TITLE
Bump snapshot version to 1.1.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.1.18-SNAPSHOT
+version = 1.1.19-SNAPSHOT
 
 # Versions of dependencies. Try to keep these at the same version across the deployment templates to facilitate
 # issue resolution.


### PR DESCRIPTION
With the release of `1.1.18`, this PR bumps the version to `1.1.19` in preparation for the next release.