### PR TITLE
Don't log failed score request content by default

### DIFF
--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -72,7 +72,8 @@ public class ModelsApiController implements ModelApi {
       ScoreResponse scoreResponse = scorer.score(request);
       return ResponseEntity.ok(scoreResponse);
     } catch (Exception e) {
-      log.info("Failed scoring request: {}, due to: {}", request, e.getMessage());
+      log.info("Failed scoring request due to: {}", e.getMessage());
+      log.debug(" - request content: ", request);
       log.debug(" - failure cause: ", e);
       return ResponseEntity.badRequest().build();
     }


### PR DESCRIPTION
Moves local rest server score request content logging to DEBUG. Score request content is only logged when scoring fails. The content of the request may be considered sensitive and thus we shouldn't log it by default.

Partially addresses https://github.com/h2oai/model-manager/issues/1570.