### PR TITLE
[DevOps] Snyk Integration

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -7,11 +7,10 @@ on:
       - 'v.[0-9]+.[0-100]+.[0-100]+'
     branches:
       - 'master'
-      - 'devops/snyk-integration'
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     tags:
-      - 'v.[0-9]+.[0-100]+.[0-100]+'
+      - 'v.[0-9]+.[0-9]+.[0-9]+'
     branches:
       - 'master'
 
@@ -22,23 +22,8 @@ jobs:
         id: changed-files
         with:
           files: |
-              build.gradle
-              common/jdbc/build.gradle
-              gcp-cloud-run/build.gradle
-              common/kdb-java/build.gradle
-              kdb-mojo-scorer/build.gradle
-              sql-jdbc-scorer/build.gradle
-              common/transform/build.gradle
-              local-rest-scorer/build.gradle
-              common/rest-java-model/build.gradle
-              common/rest-spring-api/build.gradle
-              gcp-vertex-ai-mojo-scorer/build.gradle
-              aws-sagemaker-hosted-scorer/build.gradle
-              common/rest-jdbc-spring-api/build.gradle
-              common/rest-vertex-ai-spring-api/build.gradle
-              aws-lambda-scorer/lambda-template/build.gradle
-              aws-lambda-scorer/terraform-recipe/build.gradle
-
+              **/build.gradle
+              
       - uses: snyk/actions/setup@master
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -7,10 +7,11 @@ on:
       - 'v.[0-9]+.[0-100]+.[0-100]+'
     branches:
       - 'master'
+      - 'devops/snyk-integration'
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -18,7 +19,7 @@ jobs:
           fetch-depth: 2
 
       - name: Check changed Deps files
-        uses: tj-actions/changed-files@v10
+        uses: tj-actions/changed-files@v35
         id: changed-files
         with:
           files: |
@@ -40,12 +41,12 @@ jobs:
               aws-lambda-scorer/terraform-recipe/build.gradle
 
       - uses: snyk/actions/setup@master
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: 'adopt'
 
-      - name: Snyk scan for Java dependancies
+      - name: Snyk scan for Java dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: snyk test --all-projects -d --fail-on=all
         env:
@@ -79,17 +80,17 @@ jobs:
 
       - name: Extract github branch/tag name
         shell: bash
-        run: echo "##[set-output name=ref;]$(echo ${GITHUB_REF##*/})"
+        run: echo "ref=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_ref
 
       - uses: snyk/actions/setup@master
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: 'adopt'
 
-      - name: Snyk scan for Java dependancies - ${{ matrix.depsfiles }}
-        run: snyk monitor --org=h2oai --remote-repo-url=DAI --file=${{ matrix.depsfiles }} --project-name=DAI/dai-deployment-templates/${{ steps.extract_ref.outputs.ref }}/${{ matrix.depsfiles }} -d
+      - name: Snyk scan for Java dependencies - ${{ matrix.depsfiles }}
+        run: snyk monitor --org=driverless-ai --remote-repo-url=dai-deployment-templates/${{ steps.extract_ref.outputs.ref }} --file=${{ matrix.depsfiles }} --project-name=DRIVERLESS-AI/dai-deployment-templates/${{ steps.extract_ref.outputs.ref }}/${{ matrix.depsfiles }} -d
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -7,6 +7,8 @@ on:
       - 'v.[0-9]+.[0-9]+.[0-9]+'
     branches:
       - 'master'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   snyk_scan_test:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -7,8 +7,6 @@ on:
       - 'v.[0-9]+.[0-9]+.[0-9]+'
     branches:
       - 'master'
-      - 'release-[0-9]+.[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   snyk_scan_test:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -1,6 +1,7 @@
 name: Snyk Security Vulnerability Scan
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     tags:


### PR DESCRIPTION
**FIXED PROBLEMS**

- Fixed deprecation issues with the `set-output` command. - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Changed the organisation to [DRIVERLESS-AI](https://app.snyk.io/org/driverless-ai).
- Invoked using new service account in Snyk (DRIVERLESS_AI_SNYK_TOKEN](https://app.snyk.io/org/driverless-ai/manage/service-accounts)) & updated the previous SNYK_TOKEN in GItHub.
- Updated GitHub Action versions for Java.
- Updated the [changed-files](https://github.com/marketplace/actions/changed-files) GitHub Action version.
- `remote-repo-url` will follow `repo/branch` format & `project-name` will follow `PRODUCT/repo/branch/file` format.

**PARENT ISSUES**

- https://github.com/h2oai/h2o-ops/issues/266
- https://github.com/h2oai/h2o-ops/issues/241