### PR TITLE
Make LOGLEVEL configurable in rest scorer

### DIFF
--- a/local-rest-scorer/src/main/resources/application.properties
+++ b/local-rest-scorer/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-logging.level.ai.h2o.mojos.deploy.common.transform.MojoScorer=${LOGLEVEL}
-logging.level.ai.h2o.mojos.deploy.local.rest.controller.ModelsApiController=${LOGLEVEL}
+logging.level.org.springframework.boot=${LOGLEVEL}

--- a/local-rest-scorer/src/main/resources/application.properties
+++ b/local-rest-scorer/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+logging.level.ai.h2o.mojos.deploy.common.transform.MojoScorer=${LOGLEVEL}
+logging.level.ai.h2o.mojos.deploy.local.rest.controller.ModelsApiController=${LOGLEVEL}

--- a/local-rest-scorer/src/main/resources/application.properties
+++ b/local-rest-scorer/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-logging.level.org.springframework.boot=${LOGLEVEL}
+logging.level.ai.h2o.mojos.deploy.common.transform.MojoScorer=${LOGLEVEL}
+logging.level.ai.h2o.mojos.deploy.local.rest.controller.ModelsApiController=${LOGLEVEL}

--- a/local-rest-scorer/src/test/resources/application.properties
+++ b/local-rest-scorer/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+org.springframework.boot.logging.LogLevel=${LOGLEVEL}


### PR DESCRIPTION
Address https://github.com/h2oai/model-manager/issues/1886

By toggle `LOGLEVEL`, logging is configurable
For instance, when `LOGLEVEL` is `debug`
```
│ 2023-03-30 17:58:05.326  INFO 1 --- [nio-8080-exec-9] a.h.m.d.l.r.c.ModelsApiController        : Got scoring request                                                                                                                                                                                                                                                                       │
│ 2023-03-30 17:58:05.331 DEBUG 1 --- [nio-8080-exec-9] a.h.m.d.common.transform.MojoScorer      : Input has 1 rows, 23 columns: [SEX, EDUCATION, MARRIAGE, AGE, PAY_1, PAY_2, PAY_3, PAY_4, PAY_5, PAY_6, BILL_AMT1, BILL_AMT2, BILL_AMT3, BILL_AMT4, BILL_AMT5, BILL_AMT6, PAY_AMT1, PAY_AMT2, PAY_AMT3, PAY_AMT4, PAY_AMT5, PAY_AMT6, DEFAULT_PAYMENT_NEXT_MONTH]                         │
│ 2023-03-30 17:58:05.335 DEBUG 1 --- [nio-8080-exec-9] a.h.m.d.common.transform.MojoScorer      : Response has 1 rows, 1 columns: [LIMIT_BAL]  
```