### PR TITLE
allow MODEL_ID to override pipeline uuid

### DIFF
--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class ModelsApiController implements ModelApi {
 
+  private static final String MODEL_ID = "MODEL_ID";
   private static final Logger log = LoggerFactory.getLogger(ModelsApiController.class);
 
   private final MojoScorer scorer;
@@ -57,7 +58,11 @@ public class ModelsApiController implements ModelApi {
 
   @Override
   public ResponseEntity<String> getModelId() {
-    return ResponseEntity.ok(scorer.getModelId());
+    try {
+      return ResponseEntity.ok(System.getenv(MODEL_ID));
+    } catch (Exception ignored) {
+      return ResponseEntity.ok(scorer.getModelId());
+    }
   }
 
   @Override


### PR DESCRIPTION
Can not repro https://github.com/h2oai/model-manager/issues/1820 but this PR will make sure scoring API always pull from overwritten `MODEL_ID` passed through deployment