### PR TITLE
Handle scroing exception at API layer

### DIFF
--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -11,6 +11,7 @@ import ai.h2o.mojos.deploy.common.transform.MojoScorer;
 import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
 import ai.h2o.mojos.deploy.common.transform.ShapleyLoadOption;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -77,10 +78,16 @@ public class ModelsApiController implements ModelApi {
       ScoreResponse scoreResponse = scorer.score(request);
       return ResponseEntity.ok(scoreResponse);
     } catch (Exception e) {
-      log.info("Failed scoring request due to: {}", e.getMessage());
+      log.error("Failed scoring request", e);
       log.debug(" - request content: ", request);
       log.debug(" - failure cause: ", e);
-      return ResponseEntity.badRequest().build();
+      return new ResponseEntity(
+          ImmutableMap
+              .builder()
+              .put("detail", String.format("Failed scoring request due to: %s", e))
+              .build(),
+          HttpStatus.INTERNAL_SERVER_ERROR
+      );
     }
   }
 
@@ -94,13 +101,25 @@ public class ModelsApiController implements ModelApi {
       log.info("Got scoring request for CSV");
       return ResponseEntity.ok(scorer.scoreCsv(file));
     } catch (IOException e) {
-      log.info("Failed loading CSV file: {}, due to: {}", file, e.getMessage());
+      log.error("Failed loading CSV file: {}", file, e);
       log.debug(" - failure cause: ", e);
-      return ResponseEntity.badRequest().build();
+      return new ResponseEntity(
+          ImmutableMap
+              .builder()
+              .put("detail", String.format("Failed loading CSV file due to: %s", e))
+              .build(),
+          HttpStatus.INTERNAL_SERVER_ERROR
+      );
     } catch (Exception e) {
-      log.info("Failed scoring CSV file: {}, due to: {}", file, e.getMessage());
+      log.error("Failed scoring CSV file: {}", file, e);
       log.debug(" - failure cause: ", e);
-      return ResponseEntity.badRequest().build();
+      return new ResponseEntity(
+          ImmutableMap
+              .builder()
+              .put("detail", String.format("Failed scoring CSV file due to: %s", e))
+              .build(),
+          HttpStatus.INTERNAL_SERVER_ERROR
+      );
     }
   }
 
@@ -113,12 +132,20 @@ public class ModelsApiController implements ModelApi {
               = scorer.computeContribution(request);
       return ResponseEntity.ok(contributionResponse);
     } catch (UnsupportedOperationException e) {
-      log.info("Unsupported operation due to: {}", e.getMessage());
+      log.error("Unsupported operation due to: {}", e.getMessage());
       return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     } catch (Exception e) {
-      log.info("Failed shapley contribution request due to: {}", e.getMessage());
+      log.error("Failed shapley contribution request", e);
       log.debug(" - failure cause: ", e);
-      return ResponseEntity.badRequest().build();
+      return new ResponseEntity(
+          ImmutableMap
+              .builder()
+              .put(
+                  "detail",
+                  String.format("Failed shapley contribution request due to: %s", e)
+              ).build(),
+          HttpStatus.INTERNAL_SERVER_ERROR
+      );
     }
   }
 

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -11,7 +11,6 @@ import ai.h2o.mojos.deploy.common.transform.MojoScorer;
 import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
 import ai.h2o.mojos.deploy.common.transform.ShapleyLoadOption;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -22,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.server.ResponseStatusException;
 
 @Controller
 public class ModelsApiController implements ModelApi {
@@ -78,16 +78,12 @@ public class ModelsApiController implements ModelApi {
       ScoreResponse scoreResponse = scorer.score(request);
       return ResponseEntity.ok(scoreResponse);
     } catch (Exception e) {
-      log.error("Failed scoring request", e);
+      log.error("Failed scoring request due to: {}", e.getMessage());
       log.debug(" - request content: ", request);
       log.debug(" - failure cause: ", e);
-      return new ResponseEntity(
-          ImmutableMap
-              .builder()
-              .put("detail", String.format("Failed scoring request due to: %s", e))
-              .build(),
-          HttpStatus.INTERNAL_SERVER_ERROR
-      );
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          String.format("Failed scoring request due to: %s", e.getMessage()), e);
     }
   }
 
@@ -101,25 +97,17 @@ public class ModelsApiController implements ModelApi {
       log.info("Got scoring request for CSV");
       return ResponseEntity.ok(scorer.scoreCsv(file));
     } catch (IOException e) {
-      log.error("Failed loading CSV file: {}", file, e);
+      log.error("Failed loading CSV file {} due to: {}", file, e.getMessage());
       log.debug(" - failure cause: ", e);
-      return new ResponseEntity(
-          ImmutableMap
-              .builder()
-              .put("detail", String.format("Failed loading CSV file due to: %s", e))
-              .build(),
-          HttpStatus.INTERNAL_SERVER_ERROR
-      );
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          String.format("Failed loading CSV file due to: %s", e.getMessage()), e);
     } catch (Exception e) {
-      log.error("Failed scoring CSV file: {}", file, e);
+      log.error("Failed scoring CSV file {} due to: {}", file, e.getMessage());
       log.debug(" - failure cause: ", e);
-      return new ResponseEntity(
-          ImmutableMap
-              .builder()
-              .put("detail", String.format("Failed scoring CSV file due to: %s", e))
-              .build(),
-          HttpStatus.INTERNAL_SERVER_ERROR
-      );
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          String.format("Failed scoring CSV file due to: %s", e.getMessage()), e);
     }
   }
 
@@ -133,19 +121,15 @@ public class ModelsApiController implements ModelApi {
       return ResponseEntity.ok(contributionResponse);
     } catch (UnsupportedOperationException e) {
       log.error("Unsupported operation due to: {}", e.getMessage());
-      return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+      throw new ResponseStatusException(
+          HttpStatus.NOT_IMPLEMENTED,
+          String.format("Unsupported operation due to: %s", e.getMessage()), e);
     } catch (Exception e) {
-      log.error("Failed shapley contribution request", e);
+      log.error("Failed shapley contribution request due to: {}", e.getMessage());
       log.debug(" - failure cause: ", e);
-      return new ResponseEntity(
-          ImmutableMap
-              .builder()
-              .put(
-                  "detail",
-                  String.format("Failed shapley contribution request due to: %s", e)
-              ).build(),
-          HttpStatus.INTERNAL_SERVER_ERROR
-      );
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          String.format("Failed shapley contribution request due to: %s", e), e);
     }
   }
 

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/error/ModelsExceptionHandler.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/error/ModelsExceptionHandler.java
@@ -1,0 +1,48 @@
+package ai.h2o.mojos.deploy.local.rest.error;
+
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class ModelsExceptionHandler extends ResponseEntityExceptionHandler {
+  private static final Logger log = LoggerFactory.getLogger(ModelsExceptionHandler.class);
+
+  /**
+   * Custom Exception handler for ResponseStatusException type.
+   */
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<Object> handleResponseStatusException(
+      ResponseStatusException exception, WebRequest request) {
+    log.error("Runtime exception occurred : {}", exception.getMessage(), exception);
+    return ResponseEntity
+        .status(exception.getStatus())
+        .body(ImmutableMap
+          .builder()
+          .put("detail", exception.getMessage())
+          .build()
+        );
+  }
+
+  /**
+   * Custom Exception handler for all Exception type.
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Object> handleAllException(
+      Exception exception, WebRequest request) {
+    log.error("Unexpected exception occurred : {}", exception.getMessage(), exception);
+    return ResponseEntity
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(ImmutableMap
+          .builder()
+          .put("detail", exception.getMessage())
+          .build());
+  }
+}

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/error/ModelsExceptionHandler.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/error/ModelsExceptionHandler.java
@@ -3,7 +3,6 @@ package ai.h2o.mojos.deploy.local.rest.error;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/error/ModelsExceptionHandler.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/error/ModelsExceptionHandler.java
@@ -39,10 +39,7 @@ public class ModelsExceptionHandler extends ResponseEntityExceptionHandler {
       Exception exception, WebRequest request) {
     log.error("Unexpected exception occurred : {}", exception.getMessage(), exception);
     return ResponseEntity
-        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(ImmutableMap
-          .builder()
-          .put("detail", exception.getMessage())
-          .build());
+        .internalServerError()
+        .body(ImmutableMap.builder().put("detail", exception.getMessage()).build());
   }
 }

--- a/local-rest-scorer/src/test/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiControllerTest.java
+++ b/local-rest-scorer/src/test/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiControllerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ai.h2o.mojos.deploy.common.rest.model.CapabilityType;
-import ai.h2o.mojos.deploy.common.rest.model.ContributionRequest;
 import ai.h2o.mojos.deploy.common.rest.model.ScoreRequest;
 import ai.h2o.mojos.deploy.common.transform.MojoScorer;
 import ai.h2o.mojos.deploy.common.transform.SampleRequestBuilder;
@@ -19,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -31,6 +29,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 
 @ExtendWith(MockitoExtension.class)
 class ModelsApiControllerTest {
@@ -131,12 +130,14 @@ class ModelsApiControllerTest {
 
     ModelsApiController controller = new ModelsApiController(scorer, sampleRequestBuilder);
 
-    // When
-    ResponseEntity resp = controller.getScore(new ScoreRequest());
-
-    // Then
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
-    assertTrue(resp.getBody() instanceof Map);
+    // When & Then
+    try {
+      controller.getScore(new ScoreRequest());
+    } catch (Exception ex) {
+      assertTrue(ex instanceof ResponseStatusException);
+      assertTrue(ex.getCause() instanceof IllegalStateException);
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ((ResponseStatusException) ex).getStatus());
+    }
   }
 
   @Test
@@ -144,16 +145,17 @@ class ModelsApiControllerTest {
     // Given
     MojoScorer scorer = mock(MojoScorer.class);
     when(scorer.getEnabledShapleyTypes()).thenReturn(ShapleyLoadOption.TRANSFORMED);
-    when(scorer.scoreCsv("Test File")).thenThrow(new IllegalStateException("Test Exception"));
 
     ModelsApiController controller = new ModelsApiController(scorer, sampleRequestBuilder);
 
-    // When
-    ResponseEntity resp = controller.getScoreByFile("Test File");
-
-    // Then
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
-    assertTrue(resp.getBody() instanceof Map);
+    // When & Then
+    try {
+      controller.getScore(new ScoreRequest());
+    } catch (Exception ex) {
+      assertTrue(ex instanceof ResponseStatusException);
+      assertTrue(ex.getCause() instanceof IllegalStateException);
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ((ResponseStatusException) ex).getStatus());
+    }
   }
 
   @Test
@@ -161,15 +163,16 @@ class ModelsApiControllerTest {
     // Given
     MojoScorer scorer = mock(MojoScorer.class);
     when(scorer.getEnabledShapleyTypes()).thenReturn(ShapleyLoadOption.TRANSFORMED);
-    when(scorer.computeContribution(any())).thenThrow(new IllegalStateException("Test Exception"));
 
     ModelsApiController controller = new ModelsApiController(scorer, sampleRequestBuilder);
 
-    // When
-    ResponseEntity resp = controller.getContribution(new ContributionRequest());
-
-    // Then
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
-    assertTrue(resp.getBody() instanceof Map);
+    // When & Then
+    try {
+      controller.getScore(new ScoreRequest());
+    } catch (Exception ex) {
+      assertTrue(ex instanceof ResponseStatusException);
+      assertTrue(ex.getCause() instanceof IllegalStateException);
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ((ResponseStatusException) ex).getStatus());
+    }
   }
 }


### PR DESCRIPTION
Part of https://github.com/h2oai/model-manager/issues/1891

## demo
```
jinghan@JHan-MBP16 h2o % curl -X POST -H "Content-Type: application/json" -d @- https://model.jh-test-1.mlops-dev.h2o.ai/3f49b90c-27a4-40bb-acd7-4b12d84f8367/model/score << EOF
{
  "fields": [
    "timestamp",
    "count",
    "visibility",
    "temperature",
    "windSpeed",
    "humidity",
    "pressure",
    "substation"
  ],
  "rows": [
    [
      "text",
      "this is a test",
      "0",
      "0",
      "0",
      "0",
      "0",
      "0"
    ]
  ]
}
EOF
Illegal Server response: {"detail":"Failed scoring request due to: java.lang.NumberFormatException: For input string: \"this is a test\""}
```