### PR TITLE
build: upgrade CodeQL GH Action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/common/transform/build.gradle
+++ b/common/transform/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     // by mojo2-runtime-impl. The problem is that mojo2 does not expose that dependency
     // as compile time dependency for consumers.
     implementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
+    testImplementation group: 'joda-time', name: 'joda-time', version: '2.9.9'
+    // end of fixme
 
     testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.4.0'


### PR DESCRIPTION
Followed https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/
