### PR TITLE
[DevOps] Remove non-production dependencies from Snyk scan

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -8,10 +8,11 @@ on:
       - 'v.[0-9]+.[0-9]+.[0-9]+'
     branches:
       - 'master'
+      - 'devops/snyk-optimization'
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -33,7 +34,12 @@ jobs:
 
       - name: Snyk scan for Java dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: snyk test --all-projects -d --fail-on=all
+        run: snyk test \
+          --all-projects \
+          -d \
+          --fail-on=all \
+          --print-deps \
+          --configuration-matching='^\(compile\|runtime\)'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
@@ -75,7 +81,14 @@ jobs:
           distribution: 'adopt'
 
       - name: Snyk scan for Java dependencies - ${{ matrix.depsfiles }}
-        run: snyk monitor --org=driverless-ai --remote-repo-url=dai-deployment-templates/${{ steps.extract_ref.outputs.ref }} --file=${{ matrix.depsfiles }} --project-name=DRIVERLESS-AI/dai-deployment-templates/${{ steps.extract_ref.outputs.ref }}/${{ matrix.depsfiles }} -d
+        run: snyk monitor \
+          --org=driverless-ai \
+          --remote-repo-url=dai-deployment-templates/${{ steps.extract_ref.outputs.ref }} \
+          --file=${{ matrix.depsfiles }} \
+          --project-name=DRIVERLESS-AI/dai-deployment-templates/${{ steps.extract_ref.outputs.ref }}/${{ matrix.depsfiles }} \
+          -d \
+          --print-deps \
+          --configuration-matching='^\(compile\|runtime\)'
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -8,11 +8,10 @@ on:
       - 'v.[0-9]+.[0-9]+.[0-9]+'
     branches:
       - 'master'
-      - 'devops/snyk-optimization'
 
 jobs:
   snyk_scan_test:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/build.gradle
+++ b/build.gradle
@@ -55,4 +55,3 @@ task distributionZip(type: Zip) {
 task printVersion {
     println project.version
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -55,3 +55,4 @@ task distributionZip(type: Zip) {
 task printVersion {
     println project.version
 }
+


### PR DESCRIPTION
### Notes

- Added `--configuration-matching='^\(compile\|runtime\)'` argument to only match dependencies with compile & runtime configurations.
- Formatted & added `--print-deps` for clarity.
- Scan results: https://app.snyk.io/org/driverless-ai/projects

### Parent Issue

- https://github.com/h2oai/h2o-ops/issues/311

### References

- https://github.com/h2oai/mojo2/pull/1680/files#diff-aaaabb7a31d2478cd39520b23197235a66b258d3e8ef86976b831a1bec837dd9L52-L86
- https://docs.snyk.io/snyk-cli/commands/monitor#configuration-matching-less-than-configuration_regex-greater-than
- https://docs.snyk.io/snyk-cli/commands/test#configuration-matching-less-than-configuration_regex-greater-than