### PR TITLE
Overwrite id field in response with correct experiment id

### DIFF
--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation group: 'org.mockito', name : 'mockito-core'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params'
+    testImplementation group: 'uk.org.webcompere', name: 'system-stubs-jupiter'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
 }
 

--- a/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
+++ b/local-rest-scorer/src/main/java/ai/h2o/mojos/deploy/local/rest/controller/ModelsApiController.java
@@ -56,16 +56,12 @@ public class ModelsApiController implements ModelApi {
 
   @Override
   public ResponseEntity<Model> getModelInfo() {
-    return ResponseEntity.ok(scorer.getModelInfo());
+    return ResponseEntity.ok(scorer.getModelInfo().id(getScorerModelId()));
   }
 
   @Override
   public ResponseEntity<String> getModelId() {
-    try {
-      return ResponseEntity.ok(System.getenv(MODEL_ID));
-    } catch (Exception ignored) {
-      return ResponseEntity.ok(scorer.getModelId());
-    }
+    return ResponseEntity.ok(getScorerModelId());
   }
 
   @Override
@@ -78,6 +74,7 @@ public class ModelsApiController implements ModelApi {
     try {
       log.info("Got scoring request");
       ScoreResponse scoreResponse = scorer.score(request);
+      scoreResponse.id(getScorerModelId());
       return ResponseEntity.ok(scoreResponse);
     } catch (IllegalArgumentException e) {
       log.error("Invalid scoring request due to: {}", e.getMessage());
@@ -157,6 +154,15 @@ public class ModelsApiController implements ModelApi {
   @Override
   public ResponseEntity<ScoreRequest> getSampleRequest() {
     return ResponseEntity.ok(sampleRequestBuilder.build(scorer.getPipeline().getInputMeta()));
+  }
+
+  private String getScorerModelId() {
+    try {
+      String res = System.getenv(MODEL_ID);
+      return res;
+    } catch (Exception ignored) {
+      return scorer.getModelId();
+    }
   }
 
   private static List<CapabilityType> assembleSupportedCapabilities(


### PR DESCRIPTION
Follow up https://github.com/h2oai/dai-deployment-templates/pull/329

overwrite model/schema and model/score response id field with proper environment id from environment variable `MODEL_ID`