### PR TITLE
Handle the case when classification model support prediction interval

### DIFF
--- a/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToScoreResponseConverter.java
+++ b/common/transform/src/main/java/ai/h2o/mojos/deploy/common/transform/MojoFrameToScoreResponseConverter.java
@@ -101,19 +101,17 @@ public class MojoFrameToScoreResponseConverter
         throw new IllegalStateException(
           "Unexpected error, prediction interval should be supported, but actually not");
       }
+      PredictionInterval predictionInterval =
+          new PredictionInterval().fields(new Row()).rows(Collections.emptyList());
       if (mojoFrame.getNcols() > 1) {
         int targetIdx = getTargetColIdx(Arrays.asList(mojoFrame.getColumnNames()));
-        PredictionInterval predictionInterval = new PredictionInterval();
         // Need to ensure target column is singular (regression).
         if (targetIdx >= 0) {
           predictionInterval.setFields(getPredictionIntervalFields(mojoFrame, targetIdx));
           predictionInterval.setRows(getPredictionIntervalRows(mojoFrame, targetIdx));
         }
-        scoreResponse.setPredictionIntervals(predictionInterval);
-      } else {
-        scoreResponse.setPredictionIntervals(
-            new PredictionInterval().fields(new Row()).rows(Collections.emptyList()));
       }
+      scoreResponse.setPredictionIntervals(predictionInterval);
     }
   }
 


### PR DESCRIPTION
Because some h2o3 model support prediction interval even with classification model, such case need to be handled properly. Without populating exception but rather fallback to default.
```
2023-06-10 09:02:37.607 ERROR 1 --- [nio-8080-exec-3] a.h.m.d.l.r.e.ModelsExceptionHandler     : Runtime exception occurred : 503 SERVICE_UNAVAILABLE "Failed scoring request due to: Unexpected error, target column does not exist in MOJO response frame"; nested exception is java.lang.IllegalStateException: Unexpected error, target column doe │
│                                                                                                                                                                                                                                                                                                                                                        │
│ org.springframework.web.server.ResponseStatusException: 503 SERVICE_UNAVAILABLE "Failed scoring request due to: Unexpected error, target column does not exist in MOJO response frame"; nested exception is java.lang.IllegalStateException: Unexpected error, target column does not exist in MOJO response frame                                     │
│     at ai.h2o.mojos.deploy.local.rest.controller.ModelsApiController.getScore(ModelsApiController.java:95) ~[classes/:na]                                                                                                                                                                                                                              │
│     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]                                                                                                                                                                                                                                                         │
│     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]                                                                                                                                                                                                                                       │
│     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]                                                                                                                                                                                                                               │
│     at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]                                                                                                                                                                                                                                                                             │
│     at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                         │
│     at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                 │
│     at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                  │
│     at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                │
│     at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                     │
│     at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                                         │
│     at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                                                                    │
│     at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                                                                      │
│     at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                                                                  │
│     at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:909) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                                                                           │
│     at javax.servlet.http.HttpServlet.service(HttpServlet.java:681) ~[tomcat-embed-core-9.0.63.jar:4.0.FR]                                                                                                                                                                                                                                             │
│     at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc-5.3.20.jar:5.3.20]                                                                                                                                                                                                                          │
│     at javax.servlet.http.HttpServlet.service(HttpServlet.java:764) ~[tomcat-embed-core-9.0.63.jar:4.0.FR]                                                                                                                                                                                                                                             │
│     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                        │
│     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                │
│     at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53) ~[tomcat-embed-websocket-9.0.63.jar:9.0.63]                                                                                                                                                                                                                              │
│     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                        │
│     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                │
│     at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                             │
│     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                                     │
│     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                        │
│     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                │
│     at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                                    │
│     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                                     │
│     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                        │
│     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                │
│     at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                       │
│     at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.20.jar:5.3.20]                                                                                                                                                                                                                     │
│     at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                        │
│     at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                │
│     at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:197) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                      │
│     at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                       │
│     at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                   │
│     at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:135) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                            │
│     at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                             │
│     at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                         │
│     at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:769) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                                  │
│     at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:360) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                              │
│     at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                               │
│     at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                         │
│     at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:890) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                  │
│     at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1743) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                      │
│     at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                          │
│     at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                │
│     at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                │
│     at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.63.jar:9.0.63]                                                                                                                                                                                                                       │
│     at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]                                                                                                                                                                                                                                                                                        │
│ Caused by: java.lang.IllegalStateException: Unexpected error, target column does not exist in MOJO response frame                                                                                                                                                                                                                                      │
│     at ai.h2o.mojos.deploy.common.transform.MojoFrameToScoreResponseConverter.getTargetFieldIndices(MojoFrameToScoreResponseConverter.java:172) ~[transform-1.1.20.jar:na]                                                                                                                                                                             │
│     at ai.h2o.mojos.deploy.common.transform.MojoFrameToScoreResponseConverter.getTargetRows(MojoFrameToScoreResponseConverter.java:127) ~[transform-1.1.20.jar:na]                                                                                                                                                                                     │
│     at ai.h2o.mojos.deploy.common.transform.MojoFrameToScoreResponseConverter.fillOutputRows(MojoFrameToScoreResponseConverter.java:84) ~[transform-1.1.20.jar:na]                                                                                                                                                                                     │
│     at ai.h2o.mojos.deploy.common.transform.MojoFrameToScoreResponseConverter.apply(MojoFrameToScoreResponseConverter.java:61) ~[transform-1.1.20.jar:na]                                                                                                                                                                                              │
│     at ai.h2o.mojos.deploy.common.transform.MojoScorer.score(MojoScorer.java:114) ~[transform-1.1.20.jar:na]                                                                                                                                                                                                                                           │
│     at ai.h2o.mojos.deploy.local.rest.controller.ModelsApiController.getScore(ModelsApiController.java:80) ~[classes/:na]
```