### PR TITLE
Upgrade mojo2 to 2.8.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ version = 1.1.21-SNAPSHOT
 
 # Internal dependencies:
 h2oVersion = 3.40.0.3
-mojoRuntimeVersion = 2.8.1
+mojoRuntimeVersion = 2.8.2
 
 # External dependencies:
 awsLambdaCoreVersion = 1.2.0


### PR DESCRIPTION
release note: https://github.com/h2oai/mojo2/releases/tag/v2.8.2