### PR TITLE
Update jib plugin to address jenkins CI error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,14 +169,16 @@ pipeline {
                         def imageTags = isMasterBranch() || isReleaseBranch() ? "${versionText},${gitCommitHash}" : "${gitCommitHash}"
                         withDockerCredentials(DOCKERHUB_CREDS, "FROM_") {
                             withDockerCredentials("harbor.h2o.ai", "TO_") {
-                                sh "./gradlew --init-script init.gradle jib \
-                                -Djib.to.auth.username=${TO_DOCKER_USERNAME} \
-                                -Djib.to.auth.password=${TO_DOCKER_PASSWORD} \
-                                -Djib.from.auth.username=${FROM_DOCKER_USERNAME} \
-                                -Djib.from.auth.password=${FROM_DOCKER_PASSWORD} \
-                                -Djib.to.tags=${imageTags} \
-                                -Djib.allowInsecureRegistries=true \
-                                -DsendCredentialsOverHttp=true"
+                                withEnv(["XDG_CONFIG_HOME=/tmp", "XDG_CACHE_HOME=/tmp"]) {
+                                    sh "./gradlew --init-script init.gradle jib \
+                                    -Djib.to.auth.username=${TO_DOCKER_USERNAME} \
+                                    -Djib.to.auth.password=${TO_DOCKER_PASSWORD} \
+                                    -Djib.from.auth.username=${FROM_DOCKER_USERNAME} \
+                                    -Djib.from.auth.password=${FROM_DOCKER_PASSWORD} \
+                                    -Djib.to.tags=${imageTags} \
+                                    -Djib.allowInsecureRegistries=true \
+                                    -DsendCredentialsOverHttp=true"
+                                }
                             }
                         }
                     }
@@ -205,13 +207,15 @@ pipeline {
                         def imageTags = isMasterBranch() || isReleaseBranch() ? "${versionText},${gitCommitHash}" : "${gitCommitHash}"
                         withDockerCredentials(DOCKERHUB_CREDS, "FROM_") {
                             withDockerCredentials(DOCKERHUB_CREDS, "TO_") {
-                                sh "./gradlew --init-script init.gradle jib \
-                                -Djib.to.auth.username=${TO_DOCKER_USERNAME} \
-                                -Djib.to.auth.password=${TO_DOCKER_PASSWORD} \
-                                -Djib.from.auth.username=${FROM_DOCKER_USERNAME} \
-                                -Djib.from.auth.password=${FROM_DOCKER_PASSWORD} \
-                                -Djib.to.tags=${imageTags} \
-                                -PdockerRepositoryPrefix=h2oai/"
+                                withEnv(["XDG_CONFIG_HOME=/tmp", "XDG_CACHE_HOME=/tmp"]) {
+                                    sh "./gradlew --init-script init.gradle jib \
+                                    -Djib.to.auth.username=${TO_DOCKER_USERNAME} \
+                                    -Djib.to.auth.password=${TO_DOCKER_PASSWORD} \
+                                    -Djib.from.auth.username=${FROM_DOCKER_USERNAME} \
+                                    -Djib.from.auth.password=${FROM_DOCKER_PASSWORD} \
+                                    -Djib.to.tags=${imageTags} \
+                                    -PdockerRepositoryPrefix=h2oai/"
+                                }
                             }
                         }
                     }
@@ -241,7 +245,7 @@ pipeline {
                         withDockerCredentials(DOCKERHUB_CREDS, "FROM_") {
                             withGCRCredentials(VORVAN_CRED) {
                                 def gcrCreds = readFile("${GCR_JSON_KEY}")
-                                withEnv(['TO_DOCKER_USERNAME=_json_key', "TO_DOCKER_PASSWORD=${gcrCreds}"]) {
+                                withEnv(['TO_DOCKER_USERNAME=_json_key', "TO_DOCKER_PASSWORD=${gcrCreds}", "XDG_CONFIG_HOME=/tmp", "XDG_CACHE_HOME=/tmp"]) {
                                     sh "./gradlew --init-script init.gradle jib \
                                     -Djib.from.auth.username=${FROM_DOCKER_USERNAME} \
                                     -Djib.from.auth.password=${FROM_DOCKER_PASSWORD} \
@@ -318,4 +322,3 @@ void withGCRCredentials(final String credentialsId, final Closure body) {
         body()
     }
 }
-

--- a/aws-sagemaker-hosted-scorer/build.gradle
+++ b/aws-sagemaker-hosted-scorer/build.gradle
@@ -49,7 +49,7 @@ jib {
         }
     }
     container {
-        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }
+        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }.toList()
         ports = ['8080']
         volumes = [
                 // mojo pipeline and license file will live here

--- a/gcp-cloud-run/build.gradle
+++ b/gcp-cloud-run/build.gradle
@@ -46,7 +46,7 @@ jib {
         }
     }
     container {
-        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }
+        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }.toList()
         ports = ['8080']
         environment = [
                 // The expected path to the DAI license file.

--- a/gcp-vertex-ai-mojo-scorer/build.gradle
+++ b/gcp-vertex-ai-mojo-scorer/build.gradle
@@ -63,7 +63,7 @@ jib {
         }
     }
     container {
-        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }
+        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }.toList()
         ports = ['8080']
         environment = [
                 // The expected path to the DAI license file.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.1.21-SNAPSHOT
+version = 1.2.1-SNAPSHOT
 
 # Versions of dependencies. Try to keep these at the same version across the deployment templates to facilitate
 # issue resolution.
@@ -40,7 +40,7 @@ tomcatVersion = 9.0.75
 springBootPluginVersion = 3.2.0
 swaggerGradlePluginVersion = 2.19.2
 errorpronePluginVersion = 3.1.0
-jibPluginVersion = 2.7.1
+jibPluginVersion = 3.4.0
 openApiGeneratorGradlePluginVersion = 7.0.1
 
 # External tools:

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -72,7 +72,7 @@ jib {
         }
     }
     container {
-        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }
+        jvmFlags = defaultJibContainerJvmFlags.split(" ").each { it.trim() }.toList()
         ports = ['8080']
         volumes = [
                 // For storing the mojo2 file with the model to be used for scoring.


### PR DESCRIPTION
Fix Jib plugin error in jenkins CI
```

[2024-02-22T08:41:04.204Z] > Task :common:rest-java-model:compileJava UP-TO-DATE

[2024-02-22T08:41:04.205Z] > Task :common:rest-java-model:processResources NO-SOURCE

[2024-02-22T08:41:04.205Z] > Task :common:rest-java-model:classes UP-TO-DATE

[2024-02-22T08:41:04.205Z] > Task :common:rest-java-model:jar UP-TO-DATE

[2024-02-22T08:41:04.504Z] > Task :common:transform:compileJava UP-TO-DATE

[2024-02-22T08:41:04.504Z] > Task :common:transform:processResources NO-SOURCE

[2024-02-22T08:41:04.504Z] > Task :common:transform:classes UP-TO-DATE

[2024-02-22T08:41:04.504Z] > Task :common:transform:jar UP-TO-DATE

[2024-02-22T08:41:04.795Z] > Task :aws-sagemaker-hosted-scorer:compileJava UP-TO-DATE

[2024-02-22T08:41:04.795Z] > Task :aws-sagemaker-hosted-scorer:processResources NO-SOURCE

[2024-02-22T08:41:04.795Z] > Task :aws-sagemaker-hosted-scorer:classes UP-TO-DATE

[2024-02-22T08:41:04.795Z] > Task :aws-sagemaker-hosted-scorer:jib FAILED

[2024-02-22T08:41:04.795Z] 

[2024-02-22T08:41:04.795Z] FAILURE: Build failed with an exception.

[2024-02-22T08:41:04.795Z] 

[2024-02-22T08:41:04.795Z] * What went wrong:

[2024-02-22T08:41:04.795Z] Execution failed for task ':aws-sagemaker-hosted-scorer:jib'.

[2024-02-22T08:41:04.795Z] > java.io.IOException: Failed to create, open, or parse global Jib config file; see https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#where-is-the-global-jib-configuration-file-and-how-i-can-configure-it to fix or you may need to delete ?/.config/google-cloud-tools-java/jib/config.json
```